### PR TITLE
Adding an estimate for percentiles

### DIFF
--- a/html/js/dashboard.js
+++ b/html/js/dashboard.js
@@ -166,7 +166,6 @@ function estimatePercentile(buckets, values, percentile) {
       break;
     }
     counted += values[i];
-    start = buckets[i];
   }
 
   // The bucket which starts at `start` and ends at `buckets[i]`. We need


### PR DESCRIPTION
As the summary says this function computes **an** estimate for percentiles, this estimate is reasonable in most cases...

I'm certainly open to other ideas as to what would make a good estimate for percentiles.
The function `estimatePercentile` in this patch works by counting occurrences until we find the bucket that contains the occurrence of interest. If we're looking for the median (50th percentile) in a histogram with 300 occurrences, we'll get the bucket containing the 150th occurrence. Once this bucket is found, we'll assume occurrences inside the bucket is uniformly distributed and interpolate the median from this.

Feel free to come up with other or better estimates :)
