### PR TITLE
Fixes 917588 - restore pre-refactor behaviors

### DIFF
--- a/html/css/main.css
+++ b/html/css/main.css
@@ -12,12 +12,13 @@ body, html {
   background: rgb(247, 249, 255);
 }
 header {
-  height: 50px;
-  line-height: 50px;
+  line-height: 2em;
   padding-left: 10px;
   font-size: 17px;
   letter-spacing: -1px;
   display: flex;
+  color: rgb(255, 204, 153);
+  background: rgb(37, 39, 49);
 }
 footer {
   padding: 1em;
@@ -28,14 +29,10 @@ article {
   flex-direction: column;
 }
 nav {
-  padding-left: 1em;
-  margin-top: 1em;
-  height: 50px;
-  line-height: 50px;
+  padding-left: 10px;
+  height: 35px;
   background: rgb(37, 39, 49);
   color: rgb(255, 204, 153);
-  font-size: 17px;
-  letter-spacing: -1px;
   display: flex;
   white-space: nowrap;
   flex: 1;
@@ -91,7 +88,7 @@ select {
 .info{
   font-size: 14px;
   padding: 10px;
-} 
+}
 #add-plot{
   right:    20px;
   position: absolute;

--- a/html/js/dashboard.js
+++ b/html/js/dashboard.js
@@ -23,7 +23,7 @@ Dashboard.init = function Dashboard_init() {
   Dashboard.hashChanged();
 
   // If not state was restored from hash, we create a little state
-  if (_plots.length == 0) {
+  if (_plots.length === 0) {
     // Create an initial plot area
     Dashboard.addPlotArea();
   }
@@ -42,14 +42,36 @@ Dashboard.init = function Dashboard_init() {
       }
     }, 100);
   });
-}
+};
 
 /** Add a new PlotArea to the dashboard */
 Dashboard.addPlotArea = function Dashboard_addPlotArea(state) {
   var plot = new Dashboard.PlotArea(state);
   _plots.push(plot);
+
+  // set up plot hover
+  var previousPoint;
+  $(plot.element()).bind("plothover", function(event, pos, item) {
+    if (!item) {
+      $("#tooltip").remove();
+      previousPoint = null;
+      return;
+    }
+    if (previousPoint == item.dataIndex) {
+      return;
+    }
+    previousPoint = item.dataIndex;
+    $("#tooltip").remove();
+    $('<div id="tooltip">' + item.datapoint[1].toFixed(2) + '</div>')
+      .css({
+        top: item.pageY + 5,
+        left: item.pageX + 5,
+      })
+      .appendTo("body").fadeIn(200);
+  });
+
   $("article").append(plot.element());
-}
+};
 
 // Last updated hash
 var _lastUpdatedHash = null;
@@ -80,7 +102,7 @@ Dashboard.updateHash = function Dashboard_updateHash() {
   }
   _lastUpdatedHash     = "#" + states.join("|");
   window.location.hash = _lastUpdatedHash;
-}
+};
 
 /** Restored state from hash */
 Dashboard.hashChanged = function Dashboard_hashChanged() {
@@ -108,7 +130,7 @@ Dashboard.hashChanged = function Dashboard_hashChanged() {
     // Create plot for state
     Dashboard.addPlotArea(state);
   }
-}
+};
 
 /**
  * A PlotArea instance creates elements necessary to choose version, measure and
@@ -136,7 +158,9 @@ function _populateSelect(options, select) {
     var option = options[i];
 
     // Add <option>
-    select.append($("<option>", {value: option, text: option}));
+    select.append(
+      $("<option>",
+      {value: option, text: option.replace('/', ' ')}));
   }
 
   // Select first option
@@ -154,7 +178,7 @@ function PlotArea(state) {
   this._element = $("<section>");
 
   // Create nav area
-  this._nav = $("<nav>")
+  this._nav = $("<nav>");
   this._element.append(this._nav);
   //this._nav.bind("change", $.proxy(this._optionChanged, this));
 
@@ -188,7 +212,7 @@ function PlotArea(state) {
   this._element.append(plots);
 
   // Place holders for plot objects
-  this._hgEvoPlot = null;    
+  this._hgEvoPlot = null;
   this._hgramPlot = null;
 
   // Restore from existing state
@@ -198,7 +222,7 @@ function PlotArea(state) {
 PlotArea.prototype.restore = function PlotArea_restore(state) {
   var that = this;
   var stateFragments = (state || "").split("/");
-  
+
   // Create version selector
   var versions = Telemetry.versions();
   var version = versions[0];
@@ -210,7 +234,6 @@ PlotArea.prototype.restore = function PlotArea_restore(state) {
   this._versionSelector.val(version);
 
   // Fetch measures
-  var that = this;
   Telemetry.measures(version, function(measures) {
     _populateSelect(measures, that._measureSelector);
 
@@ -223,7 +246,7 @@ PlotArea.prototype.restore = function PlotArea_restore(state) {
       function applyFilterOptions() {
         // Create next filter
         var filterName = hgramEvo.filterName();
-        if (filterName != null) {
+        if (filterName !== null) {
           var options = [filterName + "*"].concat(hgramEvo.filterOptions());
           var nextSelector = _populateSelect(options);
           nextSelector.data("hgramEvo", hgramEvo);
@@ -254,12 +277,12 @@ PlotArea.prototype.restore = function PlotArea_restore(state) {
       that.updatePlots();
     });
   });
-}
+};
 
 /** Get element from PlotArea */
 PlotArea.prototype.element = function PlotArea_element(){
   return this._element;
-}
+};
 
 /** Serialize this PlotArea to a minimalistic string */
 PlotArea.prototype.state = function PlotArea_state(){
@@ -281,7 +304,7 @@ PlotArea.prototype.state = function PlotArea_state(){
   //              "contains a slash \"/\"!");
   //}
   return stateFragments.join("/");
-}
+};
 
 /** Event handler for when selected version is changed */
 PlotArea.prototype._versionChanged = function PlotArea__versionChanged() {
@@ -301,7 +324,7 @@ PlotArea.prototype._versionChanged = function PlotArea__versionChanged() {
     // Now update measure
     that._measureChanged();
   });
-}
+};
 
 /** Event handler for when selected measure is changed */
 PlotArea.prototype._measureChanged = function PlotArea__measureChanged() {
@@ -315,7 +338,7 @@ PlotArea.prototype._measureChanged = function PlotArea__measureChanged() {
 
     // Create next filter
     var filterName = hgramEvo.filterName();
-    if (filterName != null) {
+    if (filterName !== null) {
       var options = [filterName + "*"].concat(hgramEvo.filterOptions());
       var nextSelector = _populateSelect(options);
       nextSelector.data("hgramEvo", hgramEvo);
@@ -326,7 +349,7 @@ PlotArea.prototype._measureChanged = function PlotArea__measureChanged() {
     that._hgramEvo = hgramEvo;
     that.updatePlots();
   });
-}
+};
 
 PlotArea.prototype._filterChanged = function PlotArea__filterChanged(e) {
   var filterSelector = $(e.target);
@@ -345,7 +368,7 @@ PlotArea.prototype._filterChanged = function PlotArea__filterChanged(e) {
 
     // Create next filter
     var filterName = hgramEvo.filterName();
-    if (filterName != null) {
+    if (filterName !== null) {
       var options = [filterName + "*"].concat(hgramEvo.filterOptions());
       var nextSelector = _populateSelect(options);
       nextSelector.data("hgramEvo", hgramEvo);
@@ -356,7 +379,7 @@ PlotArea.prototype._filterChanged = function PlotArea__filterChanged(e) {
   // Update histogram
   this._hgramEvo = hgramEvo;
   this.updatePlots();
-}
+};
 
 /** Update plots to reflect filtered data */
 PlotArea.prototype.updatePlots = function PlotArea_updatePlots(){
@@ -424,7 +447,7 @@ PlotArea.prototype.updatePlots = function PlotArea_updatePlots(){
 
   // Plot aggregated histogram
   this._hgramPlot = $.plot(this._hgramPlotDiv, hgramSeries, {
-    "xaxis": { 
+    "xaxis": {
       "ticks": aggregated_ticks
     },
     "grid": {
@@ -435,7 +458,7 @@ PlotArea.prototype.updatePlots = function PlotArea_updatePlots(){
   // Update histogram information
   this._descDiv.text(hgram.description() + " (submissions: " +
                      hgram.submissions() + ")");
-}
+};
 
 /** Resize plot area */
 PlotArea.prototype.resize = function PlotArea_resize() {
@@ -449,12 +472,13 @@ PlotArea.prototype.resize = function PlotArea_resize() {
     this._hgramPlot.setupGrid();
     this._hgramPlot.draw();
   }
-}
+};
 
 return PlotArea;
 
 })();
 
-return exports.Dashboard = Dashboard;
+exports.Dashboard = Dashboard;
+return exports.Dashboard;
 
 })(this);

--- a/html/js/telemetry.js
+++ b/html/js/telemetry.js
@@ -36,7 +36,7 @@ function _get(path, cb) {
       console.log("Telemetry._get: Failed loading " + path + " with " +
                   e.target.status);
     }
-  }
+  };
   xhr.open("get", _data_folder + "/" + path, true);
   xhr.send();
 }
@@ -57,7 +57,7 @@ Telemetry.init = function Telemetry_load(data_folder, cb) {
   // Count down files loaded
   function count_down(){
     load_count--;
-    if (load_count == 0) {
+    if (load_count === 0) {
       cb();
     }
   }
@@ -73,7 +73,7 @@ Telemetry.init = function Telemetry_load(data_folder, cb) {
     _specifications = data;
     count_down();
   });
-}
+};
 
 /** Get list of channel/version */
 Telemetry.versions = function Telemetry_versions() {
@@ -81,7 +81,7 @@ Telemetry.versions = function Telemetry_versions() {
     throw new Error("Telemetry.versions: Telemetry module isn't initialized!");
   }
   return _versions;
-}
+};
 
 /**
  * Invoke cb(list) with a list of measures available for the channel/version
@@ -96,7 +96,7 @@ Telemetry.measures = function Telemetry_measures(channel_version, cb) {
     measures.sort();
     cb(measures);
   });
-}
+};
 
 /**
  * Invoke cb(histogramEvolution) with an instance of HistogramEvolution for the
@@ -108,7 +108,7 @@ Telemetry.loadHistogram =
   var data, filter_tree;
   function count_down() {
     load_count--;
-    if (load_count == 0) {
+    if (load_count === 0) {
       var spec = _specifications[measure];
       if (spec === undefined) {
         spec = {
@@ -134,7 +134,7 @@ Telemetry.loadHistogram =
     filter_tree = json;
     count_down();
   });
-}
+};
 
 /** Auxiliary function to find all filter_ids in a filter_tree */
 function _listFilterIds(filter_tree){
@@ -218,12 +218,12 @@ Histogram.prototype.filter = function Histogram_filter(option) {
     this._filter_tree[option],
     this._spec
   );
-}
+};
 
 /** Name of filter available, null if none */
 Histogram.prototype.filterName = function Histogram_filterName() {
   return this._filter_tree.name || null;
-}
+};
 
 /** List of options available for current filter */
 Histogram.prototype.filterOptions = function Histogram_filterOptions() {
@@ -234,17 +234,17 @@ Histogram.prototype.filterOptions = function Histogram_filterOptions() {
     }
   }
   return options.sort();
-}
+};
 
 /** Get the histogram kind */
 Histogram.prototype.kind = function Histogram_kind() {
   return this._spec.kind;
-}
+};
 
 /** Get a description of the measure in this histogram */
 Histogram.prototype.description = function Histogram_description() {
   return this._spec.description;
-}
+};
 
 /** Get number of data points in this histogram */
 Histogram.prototype.count = function Histogram_count() {
@@ -254,12 +254,12 @@ Histogram.prototype.count = function Histogram_count() {
     count += _aggregate(i, this);
   }
   return count;
-}
+};
 
 /** Number of telemetry pings aggregated in this histogram */
 Histogram.prototype.submissions = function Histogram_submissions() {
   return _aggregate(DataOffsets.SUBMISSIONS, this);
-}
+};
 
 /** Get the mean of all data points in this histogram, null if N/A */
 Histogram.prototype.mean = function Histogram_mean() {
@@ -268,7 +268,7 @@ Histogram.prototype.mean = function Histogram_mean() {
   }
   var sum = _aggregate(DataOffsets.SUM, this);
   return sum / this.count();
-}
+};
 
 /** Get the geometric mean of all data points in this histogram, null if N/A */
 Histogram.prototype.geometricMean = function Histogram_geometricMean() {
@@ -277,7 +277,7 @@ Histogram.prototype.geometricMean = function Histogram_geometricMean() {
   }
   var log_sum = _aggregate(DataOffsets.LOG_SUM, this);
   return log_sum / this.count();
-}
+};
 
 /**
  * Get the standard deviation over all data points in this histogram,
@@ -292,11 +292,11 @@ Histogram.prototype.standardDeviation = function Histogram_standardDeviation() {
   var sum_sq_hi = new Big(_aggregate(DataOffsets.SUM_SQ_HI, this));
   var sum_sq_lo = new Big(_aggregate(DataOffsets.SUM_SQ_LO, this));
   var sum_sq    = sum_sq_lo.plus(sum_sq_hi.times(new Big(2).pow(32)));
-  
+
   // std. dev. = sqrt(count * sum_squares - sum * sum) / count
   // http://en.wikipedia.org/wiki/Standard_deviation#Rapid_calculation_methods
   return count.times(sum_sq).minus(sum.pow(2)).divide(count).toFixed(3);
-}
+};
 
 /**
  * Get the geometric standard deviation over all data points in this histogram,
@@ -322,7 +322,7 @@ Histogram.prototype.geometricStandardDeviation =
       ) / count
     )
   );
-}
+};
 
 /** Estimate value of a percentile, returns null, if not applicable */
 Histogram.prototype.percentile = function Histogram_percentile(percent) {
@@ -353,10 +353,10 @@ Histogram.prototype.percentile = function Histogram_percentile(percent) {
     // in buckets below i
     var sum_before_i = 0;
     for (var j = 0; j < i; j++) {
-      var nb_points = _aggregate(j, this);
+      var a_points = _aggregate(j, this);
       var bucket_center_value = (this._buckets[j+1] - this._buckets[j]) / 2 +
-                                this._buckets[j]; 
-      sum_before_i += nb_points * bucket_center_value;
+                                this._buckets[j];
+      sum_before_i += a_points * bucket_center_value;
     }
     // We estimate the sum of data-points in i by subtracting the estimate of
     // sum of data-points before i...
@@ -367,24 +367,24 @@ Histogram.prototype.percentile = function Histogram_percentile(percent) {
     end = bucket_i_mean * 2;
   }
 
-  // Fraction indicating where in bucket i the percentile is located 
+  // Fraction indicating where in bucket i the percentile is located
   var bucket_fraction = to_count / (_aggregate(i, this) + 1);
 
   if (this.kind() == "linear") {
     // Interpolate median assuming a uniform distribution between start and end.
     return start + (end - start) * bucket_fraction;
-  
+
   } else if (this.kind() == "exponential") {
     // Interpolate median assuming an exponential distribution
     return Math.exp(Math.log(start) + Math.log(end - start) * bucket_fraction);
   }
   return null;
-}
+};
 
 /** Estimate the median, returns null, if not applicable */
 Histogram.prototype.median = function Histogram_median() {
   return this.percentile(50);
-}
+};
 
 /**
  * Invoke cb(count, start, end) for every bucket in this histogram, the
@@ -399,7 +399,7 @@ Histogram.prototype.each = function Histogram_each(cb) {
     //TODO: End for the last bucket should be estimated, not null as is now
     cb(count, start, end);
   }
-}
+};
 
 return Histogram;
 
@@ -430,13 +430,13 @@ function HistogramEvolution(filter_path, data, filter_tree, spec) {
 /** Get the histogram kind */
 HistogramEvolution.prototype.kind = function HistogramEvolution_kind() {
   return this._spec.kind;
-}
+};
 
 /** Get a description of the measure in this histogram */
 HistogramEvolution.prototype.description =
                                     function HistogramEvolution_description() {
   return this._spec.description;
-}
+};
 
 /** Get new HistogramEvolution representation filtered with option */
 HistogramEvolution.prototype.filter = function histogramEvolution_filter(opt) {
@@ -449,13 +449,13 @@ HistogramEvolution.prototype.filter = function histogramEvolution_filter(opt) {
     this._filter_tree[opt],
     this._spec
   );
-}
+};
 
 /** Name of filter available, null if none */
 HistogramEvolution.prototype.filterName =
                                       function HistogramEvolution_filterName() {
   return this._filter_tree.name || null;
-}
+};
 
 /** List of options available for current filter */
 HistogramEvolution.prototype.filterOptions =
@@ -467,7 +467,7 @@ HistogramEvolution.prototype.filterOptions =
     }
   }
   return options.sort();
-}
+};
 
 /**
  * Get merged histogram for the interval [start; end], ie. start and end dates
@@ -477,7 +477,7 @@ HistogramEvolution.prototype.filterOptions =
 HistogramEvolution.prototype.range =
                                 function HistogramEvolution_range(start, end) {
   // Construct a dataset by merging all datasets/histograms in the range
-  var merged_dataset = []
+  var merged_dataset = [];
 
   // List of filter_ids we care about, instead of just merging all filters
   var filter_ids = _listFilterIds(this._filter_tree);
@@ -488,7 +488,7 @@ HistogramEvolution.prototype.range =
     // Check that date is between start and end (if start and end is defined)
     var date = _parseDateString(datekey);
     if((!start || start <= date) && (!end || date <= end)) {
-    
+
       // Find dataset of this datekey, merge filter_ids for this dataset into
       // merged_dataset.
       var dataset = this._data.values[datekey];
@@ -506,7 +506,7 @@ HistogramEvolution.prototype.range =
     this._filter_tree,
     this._spec
   );
-}
+};
 
 /** Get the list of dates in the evolution sorted by date */
 HistogramEvolution.prototype.dates = function HistogramEvolution_dates() {
@@ -515,7 +515,7 @@ HistogramEvolution.prototype.dates = function HistogramEvolution_dates() {
     dates.push(_parseDateString(date));
   }
   return dates.sort();
-}
+};
 
 /** Invoke cb(date, histogram) with each date, histogram pair ordered by date */
 HistogramEvolution.prototype.each = function HistogramEvolution_each(cb) {
@@ -537,14 +537,15 @@ HistogramEvolution.prototype.each = function HistogramEvolution_each(cb) {
         this._filter_tree,
         this._spec
       )
-    )
+    );
   }
-}
+};
 
 return HistogramEvolution;
 
 })(); /* HistogramEvolution */
 
-return exports.Telemetry = Telemetry;
+exports.Telemetry = Telemetry;
+return exports.Telemetry;
 
 })(this);


### PR DESCRIPTION
Restores plot onhover behavior, cosmetic space between product and
version in the version selector, and makes some CSS tweaks to restore
a solid color header and reduce wasted horizontal space.

If the "add plot" functionality is restored multiple plots should look
pretty alright.

This also fixes a bunch of little things that set of jshint, like missing semicolons or no-seriously-this-time-comparators when comparing to `null` or `0`.
