### PR TITLE
Flatten mean/percentiles based on few submissions.

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,6 +80,15 @@
                             (<a id="export-link" target="_blank">download as csv</a>)
                         </div>
                     </div>
+                    <div class="form-group">
+                        <label>Sanitize Data</label>
+                        <div class="checkbox">
+                            <label title="&quot;Very small&quot; here means the lesser of 100 submissions, or 1% of the maximum number of submissions in the range.">
+                                <input type="checkbox" name="sanitize-pref" checked>
+                                Ignore data points with very small numbers of submissions
+                            </label>
+                        </div>
+                    </div>
                 </form>
                 <h2>Summary</h2>
                 <dl class="dl-horizontal">

--- a/src/dashboard.js
+++ b/src/dashboard.js
@@ -36,6 +36,9 @@ Telemetry.init(function(){
   $('input[name=render-type]:radio').change(function() {
     update();
   });
+  $('input[name=sanitize-pref]:checkbox').change(function() {
+    update();
+  });
 });
 
 /** Format numbers */
@@ -217,6 +220,11 @@ function update(hgramEvo) {
 
   nv.addGraph(function() {
     var maxSubmissions = 0;
+
+    // Whether we actually filter submissions is controllable via the
+    // 'sanitize-pref' preference.
+    var sanitizeData = $('input[name=sanitize-pref]:checkbox').is(':checked');
+
     var submissions = hgramEvo.map(function(date, hgram) {
       if (hgram.submissions() > maxSubmissions) {
         maxSubmissions = hgram.submissions();
@@ -248,7 +256,7 @@ function update(hgramEvo) {
       var p95 = [];
       hgramEvo.each(function(date, hgram) {
         date = date.getTime();
-        if (hgram.submissions() >= submissionsCutoff) {
+        if (!sanitizeData || hgram.submissions() >= submissionsCutoff) {
           means.push({x: date, y: hgram.mean()});
           p5.push({x: date, y: hgram.percentile(5)});
           p25.push({x: date, y: hgram.percentile(25)});

--- a/style/dashboard.css
+++ b/style/dashboard.css
@@ -106,6 +106,11 @@ section {
   margin-left:  20px;
 }
 
+.checkbox {
+  margin-top:   0px;
+  margin-left:  20px;
+}
+
 .nvd3 .axis line {
   opacity: 0;
 }


### PR DESCRIPTION
The mean and percentile lines tend to get really volatile when based on a small number of submissions.  This change flattens those lines by setting the value for those lines to zero if the sample size is really small (less than 100 or 1% of the max submissions).
