### PR TITLE
Fix Date math for this week/last week.

### DIFF
--- a/mainthreadio/mainthreadio.js
+++ b/mainthreadio/mainthreadio.js
@@ -9,9 +9,9 @@ yesterday.setDate(yesterday.getDate() - 7);
 // Monday is 1, so we adjust offset accordingly
 var dowOffset = (yesterday.getUTCDay() - 1) % 7;
 var thisWeekStart = new Date(yesterday);
-var thisWeekEnd = new Date(yesterday);
 thisWeekStart.setDate(thisWeekStart.getDate() - dowOffset);
-thisWeekEnd.setDate(thisWeekStart.getDate() + 6);
+var thisWeekEnd = new Date(thisWeekStart);
+thisWeekEnd.setDate(thisWeekEnd.getDate() + 6);
 
 var lastWeekStart = new Date(thisWeekStart);
 lastWeekStart.setDate(lastWeekStart.getDate() - 7);

--- a/slowsql/slowsql.js
+++ b/slowsql/slowsql.js
@@ -10,9 +10,9 @@ yesterday.setDate(yesterday.getDate() - 7);
 // Monday is 1, so we adjust offset accordingly
 var dowOffset = (yesterday.getUTCDay() - 1) % 7;
 var thisWeekStart = new Date(yesterday);
-var thisWeekEnd = new Date(yesterday);
 thisWeekStart.setDate(thisWeekStart.getDate() - dowOffset);
-thisWeekEnd.setDate(thisWeekStart.getDate() + 6);
+var thisWeekEnd = new Date(thisWeekStart);
+thisWeekEnd.setDate(thisWeekEnd.getDate() + 6);
 
 var lastWeekStart = new Date(thisWeekStart);
 lastWeekStart.setDate(lastWeekStart.getDate() - 7);


### PR DESCRIPTION
According to this:
http://stackoverflow.com/questions/6356164/simple-javascript-date-math-not-really

You must always use the same Date object for setDate and getDate.

This was causing the date math to be wrong, and thus the dashboard couldn't
find any of the data files.

I don't know why it worked up until now, but this change appears to fix it.
