### PR TITLE
Fixed event sending

### DIFF
--- a/src/dashboard.js
+++ b/src/dashboard.js
@@ -10,8 +10,7 @@ function event() {
   var args = Array.prototype.slice.call(arguments);
   args.unshift('event');
   args.unshift('send');
-  ga.call(ga, args)
-  //console.log("Event: " + args.join(' > '));
+  ga.apply(ga, args);
 }
 
 function setCookie(cname, cvalue, exdays) {


### PR DESCRIPTION
We haven't been submitting events since we merged in the multi-series stuff...
I believe this is caused by `ga.call` instead of `ga.apply`.
