### PR TITLE
Various UI Fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
     <header>
         <h1>Telemetry Dashboard
             <span id="warning">
-            Nightly 39 data isn't trustworthy <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1069869">right now</a>
+            Firefox 39 & 40 data might have <a href="https://wiki.mozilla.org/Telemetry/Errata">selection bias</a>.
             </span>
         </h1>
     </header>

--- a/style/dashboard.css
+++ b/style/dashboard.css
@@ -34,10 +34,6 @@ header h1 {
   width:  300px !important;
 }
 
-.filter-reason {
-  width: 130px !important;
-}
-
 .filter-appName, .filter-OS, .filter-osVersion, .filter-arch {
   width: 100px !important;
 }


### PR DESCRIPTION
* Fix the main screen notice of selection bias.
* Make the filtering system more flexible:
    * Add support for "fixed options", which are always implicitly included in the filter, and use this to implement `save_session` filtering.
  * Add support for labeling options with values that are not the same as their actual values, and use this to implement friendly OS/version names. For example, "WINNT" is now shown as "Windows", and Darwin "10.0.0" is shown as "10.0.0 (Snow Leopard)".
  * Remove the "Any App" option since it is not very useful (previously known as "appName*").