### PR TITLE
Use Web Workers for background processing

### DIFF
--- a/index.html
+++ b/index.html
@@ -134,13 +134,13 @@
                         <label>Sanitize Data</label>
                         <div class="checkbox">
                             <label title="&quot;Very small&quot; here means the lesser of 100 submissions, or 1% of the maximum number of submissions in the range.">
-                                <input type="checkbox" name="sanitize-pref" checked>
+                                <input type="checkbox" id="sanitize-pref" name="sanitize-pref" checked>
                                 Ignore data points with very small numbers of submissions
                             </label>
                         </div>
                     </div>
                     <div id="tiny">
-                        <button id="tinyUrl" type="button" class="btn btn-default inline" style="padding: 1px 8px; float: left; ">TinyUrl</button>
+                        <button id="tinyUrl" type="button" class="btn btn-default inline" style="padding: 1px 8px; float: left; ">Permalink (TinyUrl)</button>
                         <div id="txtContainer" style="float: left;"></div>
                         <div style = "clear : left"></div>
                     </div>

--- a/src/dashboard.js
+++ b/src/dashboard.js
@@ -54,7 +54,7 @@ function prepareData(state, hgramEvo) {
   var maxSubmissions = 0;
   // Whether we actually filter submissions is controllable via the
   // 'sanitize-pref' preference.
-  var sanitizeData = $('input[name=sanitize-pref]:checkbox').is(':checked');
+  var sanitizeData = $('#sanitize-pref').is(':checked');
   var pgState = getPageState();
   dataKey = state + " " + pgState.evoOver + " " +  pgState.sanitize;
   if (dataKey in cachedData) {
@@ -156,7 +156,7 @@ function getPageState() {
   pageState.aggregates = pageState.aggregates.filter(function(e) { return e !== "";});
   pageState.evoOver = $('input[name=evo-type]:radio:checked').val();
   pageState.locked = gSyncWithFirst;
-  pageState.sanitize = $('input[name=sanitize-pref]:checkbox').is(':checked');
+  pageState.sanitize = $('#sanitize-pref').is(':checked');
   pageState.renderhistogram = $('input[name=render-type]:radio:checked').val();
   return pageState;
 }
@@ -197,7 +197,7 @@ function restoreFromPageState(newPageState, curPageState) {
   }
 
   if (newPageState.sanitize !== undefined) {
-    $('input[name=sanitize-pref]:checkbox').prop('checked', toBoolean(newPageState.sanitize));
+    $('#sanitize-pref').prop('checked', toBoolean(newPageState.sanitize));
   }
 
   if (newPageState.evoOver !== undefined) {
@@ -578,10 +578,10 @@ Telemetry.init(function () {
   });
 
   // Toggle whether to throw out data points from sources that haven't submitted enough
-  $('input[name=sanitize-pref]:checkbox').change(function () {
+  $('#sanitize-pref').change(function () {
     plot(true);
     // Inform google analytics of click
-    var value = $('input[name=sanitize-pref]:checkbox').is(':checked');
+    var value = $('#sanitize-pref').is(':checked');
     event('click', 'sanitize-data', value );
   });
 
@@ -844,10 +844,10 @@ function renderHistogramEvolution(lines, minDate, maxDate) {
     scaleLabel: function(valuesObject) { return fmt(valuesObject.value); },
     tooltipFontSize: 10,
     tooltipTemplate: function(valuesObject) {
-      return valuesObject.datasetLabel + " - " + valuesObject.valueLabel + " on " + valuesObject.argLabel;
+      return valuesObject.datasetLabel + " - " + valuesObject.valueLabel + " on " + moment(valuesObject.arg).format("MMM D, YYYY");
     },
     multiTooltipTemplate: function(valuesObject) {
-      return valuesObject.datasetLabel + " - " + valuesObject.valueLabel + " on " + valuesObject.argLabel;
+      return valuesObject.datasetLabel + " - " + valuesObject.valueLabel + " on " + moment(valuesObject.arg).format("MMM D, YYYY");
     },
     bezierCurveTension: 0.3,
     pointDotStrokeWidth: 0,

--- a/src/dashboard.js
+++ b/src/dashboard.js
@@ -756,11 +756,14 @@ function renderHistogramTable(hgram) {
     $('#histogram-table').show();
   }
 
+  // Build table after aggregating in the background worker
   var body = $('#histogram-table').find('tbody');
   body.empty();
-  body.append.apply(body, hgram.map(function (count, start, end, index) {
-    return $('<tr>').append($('<td>').text(fmt(start))).append($('<td>').text(fmt(end))).append($('<td>').text(fmt(count)));
-  }));
+  Telemetry.doAsync("Histogram-count", hgram, [], function(hgram, total) {
+    body.append.apply(body, hgram.map(function (count, start, end, index) {
+      return $('<tr>').append($('<td>').text(fmt(start))).append($('<td>').text(fmt(end))).append($('<td>').text(fmt(count)));
+    }));
+  });
 }
 
 function renderHistogramGraph(hgram) {

--- a/src/dashboard.js
+++ b/src/dashboard.js
@@ -772,7 +772,7 @@ function renderHistogramTable(hgram) {
   // Build table after aggregating in the background worker
   var body = $('#histogram-table').find('tbody');
   body.empty();
-  Telemetry.doAsync("Histogram-count", hgram, [], function(hgram, total) {
+  Telemetry.doAsync("Histogram_count", hgram, [], function(hgram, total) {
     body.append.apply(body, hgram.map(function (count, start, end, index) {
       return $('<tr>').append($('<td>').text(fmt(start))).append($('<td>').text(fmt(end))).append($('<td>').text(fmt(count)));
     }));
@@ -797,7 +797,7 @@ function renderHistogramGraph(hgram) {
   }
   
   // Compute chart data values
-  Telemetry.doAsync("Histogram-count", hgram, [], function(hgram, total) {
+  Telemetry.doAsync("Histogram_count", hgram, [], function(hgram, total) {
     var tooltipLabels = {};
     var labels = hgram.map(function (count, start, end, index) {
       var label = fmt(start);
@@ -935,7 +935,7 @@ function updateRendering(hgramEvo, lines, start, end) {
   $('#prop-dates').text(fmt(dates.length));
   $('#prop-date-range').text(moment(dates[0]).format("YYYY/MM/DD") + ((dates.length == 1) ?
     "" : " to " + moment(dates[dates.length - 1]).format("YYYY/MM/DD")));
-  Telemetry.doAsync("Histogram-precompute", hgram, [], function(hgram) {
+  Telemetry.doAsync("Histogram_precompute", hgram, [], function(hgram) {
     $('#prop-submissions').text(fmt(hgram.submissions()));
     $('#prop-count').text(fmt(hgram.count()));
     if (hgram.kind() == 'linear') {

--- a/v1/telemetry-worker.js
+++ b/v1/telemetry-worker.js
@@ -1,7 +1,7 @@
 importScripts("telemetry.js", "big.js")
 
 var gActions = {
-  "Histogram-count": function() {
+  Histogram_count: function() {
     // Make a shallow copy of the input object that is also a Telemetry.Histogram instance
     var histogram = new Telemetry.Histogram(this._measure, this._filter_path, this._buckets, this._dataset, this._filter_tree, this._spec);
     for (var key in this) {
@@ -20,7 +20,7 @@ var gActions = {
     }
     return result;
   },
-  "Histogram-precompute": function() {
+  Histogram_precompute: function() {
     // Make a shallow copy of the input object that is also a Telemetry.Histogram instance
     var histogram = new Telemetry.Histogram(this._measure, this._filter_path, this._buckets, this._dataset, this._filter_tree, this._spec);
     for (var key in this) {

--- a/v1/telemetry-worker.js
+++ b/v1/telemetry-worker.js
@@ -6,17 +6,31 @@ var gActions = {
     return this.count();
   },
   "Histogram-precompute": function() {
-    this.__proto__ = Telemetry.Histogram.prototype;
-    this.precomputeAggregateQuantity(Telemetry.DataOffsets.SUM);
-    this.precomputeAggregateQuantity(Telemetry.DataOffsets.LOG_SUM);
-    this.precomputeAggregateQuantity(Telemetry.DataOffsets.LOG_SUM_SQ);
-    this.precomputeAggregateQuantity(Telemetry.DataOffsets.SUM_SQ_LO);
-    this.precomputeAggregateQuantity(Telemetry.DataOffsets.SUM_SQ_HI);
-    this.precomputeAggregateQuantity(Telemetry.DataOffsets.SUBMISSIONS);
-    this.precomputeAggregateQuantity(Telemetry.DataOffsets.FILTER_ID);
-    var n = this._buckets.length;
+    // Make a shallow copy of the input object that is also a Telemetry.Histogram instance
+    var histogram = new Telemetry.Histogram(this._measure, this._filter_path, this._buckets, this._dataset, this._filter_tree, this._spec);
+    for (var key in this) {
+      if (this.hasOwnProperty(key)) {
+        histogram[key] = this[key];
+      }
+    }
+    
+    histogram.precomputeAggregateQuantity(Telemetry.DataOffsets.SUM);
+    histogram.precomputeAggregateQuantity(Telemetry.DataOffsets.LOG_SUM);
+    histogram.precomputeAggregateQuantity(Telemetry.DataOffsets.LOG_SUM_SQ);
+    histogram.precomputeAggregateQuantity(Telemetry.DataOffsets.SUM_SQ_LO);
+    histogram.precomputeAggregateQuantity(Telemetry.DataOffsets.SUM_SQ_HI);
+    histogram.precomputeAggregateQuantity(Telemetry.DataOffsets.SUBMISSIONS);
+    histogram.precomputeAggregateQuantity(Telemetry.DataOffsets.FILTER_ID);
+    var n = histogram._buckets.length;
     for (var i = 0; i < n; i++) {
-      this.precomputeAggregateQuantity(i);
+      histogram.precomputeAggregateQuantity(i);
+    }
+    
+    // Copy all the fields back into the input object
+    for (var key in histogram) {
+      if (histogram.hasOwnProperty(key)) {
+        this[key] = histogram[key];
+      }
     }
   },
 }

--- a/v1/telemetry-worker.js
+++ b/v1/telemetry-worker.js
@@ -2,8 +2,23 @@ importScripts("telemetry.js", "big.js")
 
 var gActions = {
   "Histogram-count": function() {
-    this.__proto__ = Telemetry.Histogram.prototype;
-    return this.count();
+    // Make a shallow copy of the input object that is also a Telemetry.Histogram instance
+    var histogram = new Telemetry.Histogram(this._measure, this._filter_path, this._buckets, this._dataset, this._filter_tree, this._spec);
+    for (var key in this) {
+      if (this.hasOwnProperty(key)) {
+        histogram[key] = this[key];
+      }
+    }
+    
+    var result = histogram.count();
+    
+    // Copy all the fields back into the input object
+    for (var key in histogram) {
+      if (histogram.hasOwnProperty(key)) {
+        this[key] = histogram[key];
+      }
+    }
+    return result;
   },
   "Histogram-precompute": function() {
     // Make a shallow copy of the input object that is also a Telemetry.Histogram instance

--- a/v1/telemetry.js
+++ b/v1/telemetry.js
@@ -564,7 +564,6 @@ function _parseDateString(d) {
 function _computeBuckets(spec){
   // Find bounds from specification
   var low = 1, high, nbuckets;
-  console.log(spec);
   if(spec.kind == 'boolean' || spec.kind == 'flag') {
     // This is how boolean bucket indexes are generated in mozilla-central we
     // might look into whether or not there is a bug, as it seems rather weird


### PR DESCRIPTION
* Web Workers allow us to do the heavy lifting off of the UI thread, which keeps the window responsive.
* There is still a little bit of stutter when the charts are being drawn, which is unavoidable AFAIK.
* This adds a file to the Telemetry distribution called `telemetry-worker.js`, the background worker, as well as functions like `Telemetry.doAsync` for callback-style async worker operations.
* The worker is only used for histogram precomputation and entry counting, since those were the only real hotspots.
* A small optimization to bucketing also caused a gigantic speedup in histogram evolution creation.