### PR TITLE
Small chart fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,10 +80,10 @@
                     <hr>
                     
                     <!-- single-plot histogram or table -->
-                    <h2>Distribution</h2>
-                    <figure>
+                    <figure class="single-histogram-only">
+                        <h2>Distribution</h2>
                         <canvas id="histogram"></canvas>
-                        <table id="histogram-table" class="table table-condensed" class="single-histogram-only">
+                        <table id="histogram-table" class="table table-condensed">
                             <thead>
                                 <tr>
                                     <th>Start</th>

--- a/src/dashboard.js
+++ b/src/dashboard.js
@@ -299,10 +299,6 @@ function updateUrlHashIfNeeded() {
     return;
   }
 
-  if (anyHsLoading()) {
-    return;
-  }
-
   var pageState = getPageState();
   if (window.location.hash.split("#")[1] === pageStateToUrlHash(pageState)) {
     return;

--- a/src/dashboard.js
+++ b/src/dashboard.js
@@ -107,14 +107,7 @@ function prepareData(state, hgramEvo) {
           });
         });
       } else {
-        // Histogram doesn't have enough submissions, so set everything to zero to keep the graphs looking nice
-        means.push({x: date, y: 0});
-        [5, 25, 50, 75, 95].forEach(function (p) {
-          ps[p].push({
-            x: date,
-            y: 0
-          });
-        });
+        // Histogram doesn't have enough submissions, so ignore these points entirely
       }
     });
     data.push({

--- a/src/dashboard.js
+++ b/src/dashboard.js
@@ -446,10 +446,10 @@ Telemetry.init(function () {
   
   // Add series button
   $("#addVersionButton").click(function () {
-    var state = null;
+    var state = "nightly/40/SIMPLE_MEASURES_FIRSTPAINT/saved_session/Firefox";
     event('click', 'addVersion', 'addVersion');
     if (gHistogramFilterObjects.length != 0) {
-      state = gHistogramFilterObjects[0].histogramfilter('state');
+      state = gHistogramFilterObjects[gHistogramFilterObjects.length - 1].histogramfilter('state');
     }
     addHistogramFilter(false, state);
     gSingleSeriesMode = false;


### PR DESCRIPTION
* Don't draw points at all where there aren't enough submissions.
* Update the URL hash properly when filters are added while the locking is off.
* Make newly added filters duplicate the last filter rather than the first one.
* Fix a bug in which there would not be any filters for a series that was added at first.