### PR TITLE
UI Fixes 3

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,16 +43,16 @@
         </h1>
     </header>
     <nav class="navbar navbar-default"  role="navigation">
-        <div class=" navbar-left">
-            <form id="histogram-filters" class=" navbar-form  form-inline " style= "margin: 3px;"></form>
+        <div class="navbar-left">
+            <form id="histogram-filters" class="navbar-form form-inline"></form>
+            <form class="navbar-form form-inline">
+              <button id="addVersionButton" type="button" class="btn btn-default" style="margin: 0 10px;">
+                <span class="glyphicon glyphicon-plus"></span> Add series
+              </button>
+            </form>
         </div>
-        <div class="navbar-form navbar-right">
-           <div id="addVersionButton">
-              <button type="button" class="btn btn-default" style="padding: 2px 7px;"><span class="glyphicon glyphicon-plus"></span>Add series</button>
-           </div>           
-           <div id ="multipercentile"></div>
-        </div>
-        <form id="histogram-filter" class=" navbar-form navbar-left form-inline">
+        <form class="navbar-right form-inline" style= "margin: 3px;">
+           <span id ="multipercentile"></span>
         </form>
     </nav>
     <section style="margin: 0px auto; width: 100%;" class="container">

--- a/src/dashboard.js
+++ b/src/dashboard.js
@@ -405,7 +405,11 @@ Telemetry.init(function () {
       restoreFromPageState(pgState, {});
     } else {
       // Could not restore from either url or cookie => create a default hs filter.
-      addHistogramFilter(true, "nightly/40/GC_MS/saved_session/Firefox"); //  first filter
+      var nightlies = Telemetry.versions().sort().filter(function(version) {
+        return version.startsWith("nightly/")
+      });
+      var latest_nightly = nightlies[nightlies.length - 1];
+      addHistogramFilter(true, latest_nightly + "/GC_MS/saved_session/Firefox"); //  first filter
       changeLockButton(true);  // default: locked
     }
 

--- a/src/jquery.telemetry.js
+++ b/src/jquery.telemetry.js
@@ -337,13 +337,15 @@ $.widget("telemetry.histogramfilter", {
     "7.": "Panther", "8.": "Tiger", "9.": "Leopard", "10.": "Snow Leopard",
     "11.": "Lion", "12.": "Mountain Lion", "13.": "Mavericks", "14.": "Yosemite",
   },
+  _ignoredOSNames: {"Windows_95": true, "Windows_98": true, "Windows_NT": true},
   _archNames: {"x86": "32-bit", "x86-64": "64-bit"},
   _getHumanReadableOptions: function histogramfilter__getHumanReadableOptions(filterName, options, os) {
     if (filterName === "OS") {
       // Replace OS names with pretty OS names where possible
       var systemNames = this._systemNames;
+      var ignoredNames = this._ignoredOSNames;
       return options.filter(function(option) {
-        return option !== "Windows_95" && option !== "Windows_NT"; // Ignore the OSs for old, non-unified pings
+        return !ignoredNames.hasOwnProperty(option); // Ignore the OSs for old, non-unified pings
       }).map(function(option) {
         return systemNames.hasOwnProperty(option) ? systemNames[option] : option;
       });


### PR DESCRIPTION
* Align the aggregate selector and move the Add Series button closer to the filters.
* Ignore Windows_98 as an OS.
* Default to selecting the latest nightly version.
* Currently live [here](http://anthony-zhang.me/telemetry-dashboard/).