### PR TITLE
Feedback

### DIFF
--- a/dist.html
+++ b/dist.html
@@ -20,8 +20,8 @@
 <body>
     <div class="container-fluid">
         <header>
-            <form id="histogram-filters" class="navbar-form inline" style="float: right; margin: 0">
-                <a href="https://etherpad.mozilla.org/new-telemetry-dash-feedback" class="btn btn-success" title="Send feedback about Telemetry dashboards">Send feedback</a>
+            <form class="navbar-form inline" style="float: right; margin: 0">
+                <a href="https://etherpad.mozilla.org/new-telemetry-dash-feedback" class="btn btn-success" title="Send feedback about Telemetry dashboards" target="_blank">Send feedback</a>
                 <a href="./evo.html" class="btn btn-default" id="switch-views" title="Switch to the evolution view">Evolution View</a>
                 <a href="./" class="btn btn-default btn-primary" title="Landing page for Telemetry dashboards">Dashboards Home</a>
                 <a href="./tutorial.html#HistogramDashboard" class="btn btn-default" id="tutorial" title="Usage tutorial for Telemetry dashboards">Usage Tutorial</a>

--- a/dist.html
+++ b/dist.html
@@ -20,8 +20,8 @@
 <body>
     <div class="container-fluid">
         <header>
-            <form class="navbar-form inline" style="float: right; margin: 0">
-                <a href="https://etherpad.mozilla.org/new-telemetry-dash-feedback" class="btn btn-success" title="Send feedback about Telemetry dashboards" target="_blank">Send feedback</a>
+            <form class="navbar-form inline pull-right">
+                <a href="https://etherpad.mozilla.org/new-telemetry-dash-feedback" class="btn btn-success" title="Give feedback about Telemetry dashboards" target="_blank">Give feedback</a>
                 <a href="./evo.html" class="btn btn-default" id="switch-views" title="Switch to the evolution view">Evolution View</a>
                 <a href="./" class="btn btn-default btn-primary" title="Landing page for Telemetry dashboards">Dashboards Home</a>
                 <a href="./tutorial.html#HistogramDashboard" class="btn btn-default" id="tutorial" title="Usage tutorial for Telemetry dashboards">Usage Tutorial</a>

--- a/dist.html
+++ b/dist.html
@@ -94,8 +94,8 @@
                                     <label><input name="cumulative-toggle" type="radio" value="1"> Cumulative</label>
                                 </div>
                                 <div>
-                                    Date range variable: filter submissions by build ID range or submission date range:
-                                    <label><input name="build-time-toggle" type="radio" value="0"> Build Date</label>
+                                    Date range variable: filter submissions by build/release date range or submission date range:
+                                    <label><input name="build-time-toggle" type="radio" value="0"> Build/Release Date</label>
                                     <label><input name="build-time-toggle" type="radio" value="1"> Submission Date</label>
                                 </div>
                                 <span id="date-range-controls" class="form-group" style="width: 230px; display: inline-block; margin: 0">

--- a/evo.html
+++ b/evo.html
@@ -19,8 +19,8 @@
 <body>
     <div class="container-fluid">
         <header>
-            <form class="navbar-form" style="float: right; margin: 0">
-                <a href="https://etherpad.mozilla.org/new-telemetry-dash-feedback" class="btn btn-success" title="Send feedback about Telemetry dashboards" target="_blank">Send feedback</a>
+            <form class="navbar-form pull-right">
+                <a href="https://etherpad.mozilla.org/new-telemetry-dash-feedback" class="btn btn-success" title="Give feedback about Telemetry dashboards" target="_blank">Give feedback</a>
                 <a href="./dist.html" class="btn btn-default" id="switch-views" title="Switch to the distribution view">Distribution View</a>
                 <a href="./" class="btn btn-default btn-primary" title="Landing page for Telemetry dashboards">Dashboards Home</a>
                 <a href="./tutorial.html#EvolutionDashboard" id="tutorial" class="btn btn-default" title="Usage tutorial for Telemetry dashboards">Usage Tutorial</a>

--- a/evo.html
+++ b/evo.html
@@ -20,7 +20,7 @@
     <div class="container-fluid">
         <header>
             <form class="navbar-form" style="float: right; margin: 0">
-                <a href="https://etherpad.mozilla.org/new-telemetry-dash-feedback" class="btn btn-success" title="Send feedback about Telemetry dashboards">Send feedback</a>
+                <a href="https://etherpad.mozilla.org/new-telemetry-dash-feedback" class="btn btn-success" title="Send feedback about Telemetry dashboards" target="_blank">Send feedback</a>
                 <a href="./dist.html" class="btn btn-default" id="switch-views" title="Switch to the distribution view">Distribution View</a>
                 <a href="./" class="btn btn-default btn-primary" title="Landing page for Telemetry dashboards">Dashboards Home</a>
                 <a href="./tutorial.html#EvolutionDashboard" id="tutorial" class="btn btn-default" title="Usage tutorial for Telemetry dashboards">Usage Tutorial</a>

--- a/evo.html
+++ b/evo.html
@@ -73,8 +73,8 @@
                         <div class="panel-body">
                             <form class="form-horizontal">
                                 <div>
-                                    Evolution variable: show evolution over build ID or submission date:
-                                    <label><input name="build-time-toggle" type="radio" value="0"> Build Date</label>
+                                    Evolution variable: show evolution over build/release date or submission date:
+                                    <label><input name="build-time-toggle" type="radio" value="0"> Build/Release Date</label>
                                     <label><input name="build-time-toggle" type="radio" value="1"> Submission Date</label>
                                 </div>
                                 <div>

--- a/index.html
+++ b/index.html
@@ -23,6 +23,9 @@
 <body>
     <div class="container-fluid">
         <header>
+            <form class="navbar-form inline" style="float: right; margin: 0">
+                <a href="https://etherpad.mozilla.org/new-telemetry-dash-feedback" class="btn btn-success" title="Send feedback about Telemetry dashboards" target="_blank">Send feedback</a>
+            </form>
             <h1>Telemetry Dashboards</h1>
         </header>
         <div class="row">

--- a/index.html
+++ b/index.html
@@ -23,8 +23,8 @@
 <body>
     <div class="container-fluid">
         <header>
-            <form class="navbar-form inline" style="float: right; margin: 0">
-                <a href="https://etherpad.mozilla.org/new-telemetry-dash-feedback" class="btn btn-success" title="Send feedback about Telemetry dashboards" target="_blank">Send feedback</a>
+            <form class="navbar-form inline pull-right">
+                <a href="https://etherpad.mozilla.org/new-telemetry-dash-feedback" class="btn btn-success" title="Give feedback about Telemetry dashboards" target="_blank">Give feedback</a>
             </form>
             <h1>Telemetry Dashboards</h1>
         </header>

--- a/src/dashboards.js
+++ b/src/dashboards.js
@@ -99,11 +99,11 @@ function loadStateFromUrlAndCookie() {
   });
 
   // Process the saved state value
-  pageState.aggregates = ["median"];
   if (typeof pageState.aggregates === "string") {
     var aggregates = pageState.aggregates.split("!").filter(function(v) { return v in ["5th-percentile", "25th-percentile", "median", "75th-percentile", "95th-percentile", "mean"]; });
     if (aggregates.length > 0) { pageState.aggregates = aggregates; }
-  }
+    else { pageState.aggregates = ["median"]; }
+  } else { pageState.aggregates = ["median"]; }
   pageState.measure = typeof pageState.measure === "string" && pageState.measure !== "" && pageState.measure !== "null" ? pageState.measure : "GC_MS";
   pageState.min_channel_version = typeof pageState.min_channel_version === "string" && pageState.min_channel_version.indexOf("/") >= 0 ?
     pageState.min_channel_version : "nightly/39";

--- a/src/dashboards.js
+++ b/src/dashboards.js
@@ -18,6 +18,7 @@ $(document).ready(function() {
       options.filterBehavior = "custom";
       options.filterCallback = function(element, query) {
         var value = $(element).find("label").text().toLowerCase();
+        query = query.toLowerCase();
         return value.indexOf(query) >= 0 || value.replace(/_/g, " ").indexOf(query) >= 0;
       };
     }

--- a/src/evo.js
+++ b/src/evo.js
@@ -53,20 +53,9 @@ Telemetry.init(function() {
       $("#measure").change(function() {
         // Update the measure description
         var measure = $("#measure").val();
-        var measureEntry = gMeasureMap[measure];
-        $("#measure-description").text(measureEntry.description + " (" + measure + ")");
+        var description = gMeasureMap[measure].description;
+        $("#measure-description").text(description + " (" + measure + ")");
         $("#submissions-title").text(measure + " submissions");
-        
-        // Figure out which aggregates actually apply to this measure
-        var options;
-        if (measureEntry.kind == "linear" || measureEntry.kind == "exponential") {
-          options = [["median", "Median"], ["mean", "Mean"], ["5th-percentile", "5th Percentile"], ["25th-percentile", "25th Percentile"], ["75th-percentile", "75th Percentile"], ["95th-percentile", "95th Percentile"]]
-        } else {
-          options = [["submissions", "Submissions"]];
-        }
-        
-        // Set the new aggregate options that apply to the current measure
-        multiselectSetOptions($("#aggregates"), options, gInitialPageState.aggregates !== undefined && gInitialPageState.aggregates.length > 0 ? gInitialPageState.aggregates : [options[0][0]]);
         $("#aggregates").trigger("change");
       });
       $("input[name=build-time-toggle], input[name=sanitize-toggle], #aggregates, #filter-product, #filter-arch, #filter-os").change(function(e) {
@@ -204,7 +193,6 @@ function calculateHistogramEvolutions(callback) {
   }
 
   var versions = Telemetry.versions().filter(function(v) { return fromVersion <= v && v <= toVersion; });
-  if (versions.length > 10) { versions = versions.slice(0, 10); } // Only show up to 10 versions for performance reasons
   
   // Exclude those versions that don't actually have the measure - a measure may be selectable but nonexistant if it exists in some other version, so we just ignore this version if it doesn't have that measure
   versions = versions.filter(function(channelVersion) { return gVersionMeasureMap[channelVersion][measure] !== undefined; });

--- a/src/evo.js
+++ b/src/evo.js
@@ -393,7 +393,7 @@ function displayEvolutions(lines, submissionLines, minDate, maxDate, useSubmissi
         lineList = [lines[d.line_id - 1]];
         values = [d.value];
       }
-      var legendLabel = moment(date).format("MMM D, YYYY") + (useSubmissionDate ? ":" : " (build " + moment(date).format("YYYYMMDD") + "):");
+      var legendLabel = moment(date).format("dddd MMMM D, YYYY") + (useSubmissionDate ? ":" : " (build " + moment(date).format("YYYYMMDD") + "):");
       var legend = d3.select("#evolutions .mg-active-datapoint").text(legendLabel).style("fill", "white");
       var lineHeight = 1.1;
       lineList.forEach(function(line, i) {
@@ -454,7 +454,7 @@ function displayEvolutions(lines, submissionLines, minDate, maxDate, useSubmissi
         lineList = [submissionLines[d.line_id - 1]];
         values = [d.value];
       }
-      var legendLabel = moment(date).format("MMM D, YYYY") + (useSubmissionDate ? ":" : " (build " + moment(date).format("YYYYMMDD") + "):");
+      var legendLabel = moment(date).format("dddd MMMM D, YYYY") + (useSubmissionDate ? ":" : " (build " + moment(date).format("YYYYMMDD") + "):");
       var legend = d3.select("#submissions .mg-active-datapoint").text(legendLabel).style("fill", "white");
       var lineHeight = 1.1;
       lineList.forEach(function(line, i) {

--- a/src/evo.js
+++ b/src/evo.js
@@ -56,6 +56,16 @@ Telemetry.init(function() {
         var description = gMeasureMap[measure].description;
         $("#measure-description").text(description + " (" + measure + ")");
         $("#submissions-title").text(measure + " submissions");
+        
+        // Figure out which aggregates actually apply to this measure
+        var options;
+        if (measureEntry.kind == "linear" || measureEntry.kind == "exponential") {
+          options = [["median", "Median"], ["mean", "Mean"], ["5th-percentile", "5th Percentile"], ["25th-percentile", "25th Percentile"], ["75th-percentile", "75th Percentile"], ["95th-percentile", "95th Percentile"]];
+        } else {
+          option = [["mean", "Mean"]];
+        }
+        multiselectSetOptions($("#aggregates"), options, gInitialPageState.aggregates !== undefined && gInitialPageState.aggregates.length > 0 ? gInitialPageState.aggregates : [options[0][0]]);
+        
         $("#aggregates").trigger("change");
       });
       $("input[name=build-time-toggle], input[name=sanitize-toggle], #aggregates, #filter-product, #filter-arch, #filter-os").change(function(e) {

--- a/src/evo.js
+++ b/src/evo.js
@@ -53,16 +53,16 @@ Telemetry.init(function() {
       $("#measure").change(function() {
         // Update the measure description
         var measure = $("#measure").val();
-        var description = gMeasureMap[measure].description;
-        $("#measure-description").text(description + " (" + measure + ")");
+        var measureEntry = gMeasureMap[measure];
+        $("#measure-description").text(measureEntry.description + " (" + measure + ")");
         $("#submissions-title").text(measure + " submissions");
         
         // Figure out which aggregates actually apply to this measure
-        var options;
+        var options = [];
         if (measureEntry.kind == "linear" || measureEntry.kind == "exponential") {
           options = [["median", "Median"], ["mean", "Mean"], ["5th-percentile", "5th Percentile"], ["25th-percentile", "25th Percentile"], ["75th-percentile", "75th Percentile"], ["95th-percentile", "95th Percentile"]];
-        } else {
-          option = [["mean", "Mean"]];
+        } else if (measureEntry.kind === "boolean" || measureEntry.kind === "flag") {
+          options = [["mean", "Mean"]];
         }
         multiselectSetOptions($("#aggregates"), options, gInitialPageState.aggregates !== undefined && gInitialPageState.aggregates.length > 0 ? gInitialPageState.aggregates : [options[0][0]]);
         

--- a/v1/telemetry.js
+++ b/v1/telemetry.js
@@ -1422,10 +1422,6 @@ Histogram.prototype.count = function Histogram_count() {
  * throw an exception.
  */
 Histogram.prototype.mean = function Histogram_mean() {
-  if (this.kind() != "linear" && this.kind() != "exponential") {
-     throw new Error("Histogram.geometricMean() is only available for " +
-                     "linear and exponential histograms");
-  }
   var sum = this.precomputeAggregateQuantity(Telemetry.DataOffsets.SUM);
   return sum / this.count();
 };
@@ -1574,11 +1570,6 @@ Histogram.prototype.geometricStandardDeviation = function() {
  * @param {Number}    percent           Percentile to estimate between 1 and 100
  */
 Histogram.prototype.percentile = function Histogram_percentile(percent) {
-  if (this.kind() != "linear" && this.kind() != "exponential") {
-    throw new Error("Histogram.percentile() is only available for linear " +
-                    "and exponential histograms");
-  }
-
   var frac  = percent / 100;
   var count = this.count();
 


### PR DESCRIPTION
Implement all the feedback currently at https://etherpad.mozilla.org/new-telemetry-dash-feedback.

Snapshot:

* Probe Search in Evolution Dashboard isn't very fuzzy - mconley
* Evolution dash:
    * plotting all versions of release channel 22 to 39 doesn't plot everything
    * release channel evo should have a prompt to switch x-axis to "by date" instead of "by buildID"
    * it should be possible to see the mean for boolean histograms
    * URL:  http://mzl.la/1KL4WC2
    * clicking on Feedback should open a new tab
    * going to the url above, clicking feedback, and hitting back results in "no data available"
    * reported by Markus Stange