### PR TITLE
Modified settings

### DIFF
--- a/dist.html
+++ b/dist.html
@@ -83,7 +83,7 @@
             <div class="col-md-12">
                 <div class="panel panel-default">
                     <div class="panel-heading" role="tab">
-                        <a class="panel-title" data-toggle="collapse" href="#advanced-settings">Advanced Settings</a>
+                        <a class="panel-title" data-toggle="collapse" id="advanced-settings-toggle" href="#advanced-settings">Advanced Settings<span></span></a>
                     </div>
                     <div id="advanced-settings" class="panel-collapse collapse">
                         <div class="panel-body">
@@ -94,8 +94,8 @@
                                     <label><input name="cumulative-toggle" type="radio" value="1"> Cumulative</label>
                                 </div>
                                 <div>
-                                    Date range variable: filter submissions by build/release date range or submission date range:
-                                    <label><input name="build-time-toggle" type="radio" value="0"> Build/Release Date</label>
+                                    Date range variable: filter submissions by build date range or submission date range:
+                                    <label><input name="build-time-toggle" type="radio" value="0"> Build Date</label>
                                     <label><input name="build-time-toggle" type="radio" value="1"> Submission Date</label>
                                 </div>
                                 <span id="date-range-controls" class="form-group" style="width: 230px; display: inline-block; margin: 0">

--- a/evo.html
+++ b/evo.html
@@ -67,14 +67,14 @@
             <div class="col-md-12">
                 <div class="panel panel-default">
                     <div class="panel-heading" role="tab">
-                        <a class="panel-title" data-toggle="collapse" href="#advanced-settings">Advanced Settings</a>
+                        <a class="panel-title" data-toggle="collapse" id="advanced-settings-toggle" href="#advanced-settings">Advanced Settings<span></span></a>
                     </div>
                     <div id="advanced-settings" class="panel-collapse collapse">
                         <div class="panel-body">
                             <form class="form-horizontal">
                                 <div>
-                                    Evolution variable: show evolution over build/release date or submission date:
-                                    <label><input name="build-time-toggle" type="radio" value="0"> Build/Release Date</label>
+                                    Evolution variable: show evolution over build date or submission date:
+                                    <label><input name="build-time-toggle" type="radio" value="0"> Build Date</label>
                                     <label><input name="build-time-toggle" type="radio" value="1"> Submission Date</label>
                                 </div>
                                 <div>

--- a/src/dashboards.js
+++ b/src/dashboards.js
@@ -263,7 +263,9 @@ function multiselectSetOptions(element, options, defaultSelected) {
   
   if (options.length === 0) { element.empty().multiselect("rebuild"); return; }
   var valuesMap = {}; options.forEach(function(option) { valuesMap[option[0]] = true; });
-  var selected = (element.val() || []).filter(function(value) { return valuesMap.hasOwnProperty(value); }); // A list of options that are currently selected that will still be available in the new options
+  var selected = element.val() || [];
+  if (!$.isArray(selected)) { selected = [selected]; } // For single selects, the value is not wrapped in an array
+  selected = selected.filter(function(value) { return valuesMap.hasOwnProperty(value); }); // A list of options that are currently selected that will still be available in the new options
   
   // Check inputs
   if (defaultSelected !== null) {

--- a/src/dashboards.js
+++ b/src/dashboards.js
@@ -262,14 +262,15 @@ function multiselectSetOptions(element, options, defaultSelected) {
   defaultSelected = defaultSelected || null;
   
   if (options.length === 0) { element.empty().multiselect("rebuild"); return; }
-  var selected = element.val() || defaultSelected;
-  if (!$.isArray(selected) && selected !== null) { selected = [selected]; }
+  var valuesMap = {}; options.forEach(function(option) { valuesMap[option[0]] = true; });
+  var selected = (element.val() || []).filter(function(value) { return valuesMap.hasOwnProperty(value); }); // A list of options that are currently selected that will still be available in the new options
   
   // Check inputs
   if (defaultSelected !== null) {
     defaultSelected.forEach(function(option) {
       if (typeof option !== "string") { throw "Bad defaultSelected value: must be array of strings."; }
     });
+    if (selected.length === 0) { selected = $.isArray(defaultSelected) ? defaultSelected : [defaultSelected]; }
   }
   
   var useGroups = options[0].length === 3;
@@ -302,16 +303,8 @@ function multiselectSetOptions(element, options, defaultSelected) {
       return '<option value="' + option[0] + '">' + option[1] + '</option>';
     }).join()).multiselect("rebuild");
   }
-  
-  if (selected !== null) {
-    // Filter out the options that were selected but no longer exist
-    var availableOptionMap = {};
-    options.forEach(function(option) { availableOptionMap[option[0]] = true; });
-    selected = selected.filter(function(selectedOption) {
-      return availableOptionMap.hasOwnProperty(selectedOption);
-    });
-    element.multiselect("select", selected); // Select the original options where applicable
-  }
+
+  element.multiselect("deselectAll", false).multiselect("select", selected); // Select the original options where applicable
 }
 
 var indicate = (function() {

--- a/src/evo.js
+++ b/src/evo.js
@@ -53,6 +53,23 @@ Telemetry.init(function() {
           if (e.target.id === "min-channel-version") { $("#max-channel-version").multiselect("select", fromVersion); }
           else { $("#min-channel-version").multiselect("select", toVersion); }
         }
+        if (fromVersion.split("/")[0] !== toVersion.split("/")[0]) { // Two versions are on different channels, move the other one into the right channel
+          if (e.target.id === "min-channel-version") { // min version changed, change max version to be the largest version in the current channel
+            var channel = fromVersion.split("/")[0];
+            var maxChannelVersion = null;
+            var channelVersions = Telemetry.versions().forEach(function(version) {
+              if (version.startsWith(channel + "/")) { maxChannelVersion = version; }
+            });
+            $("#max-channel-version").multiselect("select", maxChannelVersion);
+          } else { // max version changed, change the min version to be the smallest version in the current channel
+            var channel = toVersion.split("/")[0];
+            var minChannelVersion = null;
+            var channelVersions = Telemetry.versions().forEach(function(version) {
+              if (minChannelVersion === null && version.startsWith(channel + "/")) { minChannelVersion = version; }
+            });
+            $("#min-channel-version").multiselect("select", minChannelVersion);
+          }
+        }
         updateMeasuresList(function() { $("#measure").trigger("change"); });
       });
       $("#measure").change(function() {

--- a/src/evo.js
+++ b/src/evo.js
@@ -86,9 +86,15 @@ Telemetry.init(function() {
         } else {
           options = [["mean", "Mean"]];
         }
-        multiselectSetOptions($("#aggregates"), options, gInitialPageState.aggregates !== undefined && gInitialPageState.aggregates.length > 0 ? gInitialPageState.aggregates : [options[0][0]]);
         
-        $("#aggregates").trigger("change");
+        var aggregatesFilter = $("#aggregates");
+        var oldAggregates = gInitialPageState.aggregates.filter(function(aggregate) { // Aggregates that are still available
+          return options.reduce(function(contained, option) { return contained || option[0] === aggregate }, false);
+        });
+        multiselectSetOptions(aggregatesFilter, options, oldAggregates.length > 0 ? oldAggregates : [options[0][0]]);
+        gPreviousFilterAllSelected[aggregatesFilter.attr("id")] = false;
+
+        aggregatesFilter.trigger("change");
       });
       $("input[name=build-time-toggle], input[name=sanitize-toggle], #aggregates, #filter-product, #filter-arch, #filter-os").change(function(e) {
         var $this = $(this);
@@ -99,7 +105,7 @@ Telemetry.init(function() {
           if (selected.length !== options.length && selected.length > 0 && gPreviousFilterAllSelected[$this.attr("id")]) {
             var nonSelectedOptions = options.map(function(i, option) { return option.getAttribute("value"); }).toArray()
               .filter(function(filterOption) { return selected.indexOf(filterOption) < 0; });
-            $this.multiselect("deselectAll").multiselect("select", nonSelectedOptions);
+            $this.multiselect("deselectAll", false).multiselect("select", nonSelectedOptions);
           }
           gPreviousFilterAllSelected[$this.attr("id")] = selected.length === options.length; // Store state
         

--- a/src/evo.js
+++ b/src/evo.js
@@ -25,6 +25,11 @@ Telemetry.init(function() {
   $("input[name=build-time-toggle][value=" + (gInitialPageState.use_submission_date !== 0 ? 1 : 0) + "]").prop("checked", true).trigger("change");
   $("input[name=sanitize-toggle][value=" + (gInitialPageState.sanitize !== 0 ? 1 : 0) + "]").prop("checked", true).trigger("change");
   
+  // If advanced settings are not at their defaults, expand the settings pane on load
+  if (gInitialPageState.use_submission_date !== 0 || gInitialPageState.sanitize !== 1) {
+    $("#advanced-settings-toggle").click();
+  }
+  
   updateMeasuresList(function() {
     calculateHistogramEvolutions(function(filterList, filterOptionsList, lines, submissionLines) {
       refreshFilters(filterList, filterOptionsList);
@@ -53,8 +58,8 @@ Telemetry.init(function() {
       $("#measure").change(function() {
         // Update the measure description
         var measure = $("#measure").val();
-        var description = gMeasureMap[measure].description;
-        $("#measure-description").text(description + " (" + measure + ")");
+        var measureEntry = gMeasureMap[measure];
+        $("#measure-description").text(measureEntry.description + " (" + measure + ")");
         $("#submissions-title").text(measure + " submissions");
         
         // Figure out which aggregates actually apply to this measure
@@ -62,7 +67,7 @@ Telemetry.init(function() {
         if (measureEntry.kind == "linear" || measureEntry.kind == "exponential") {
           options = [["median", "Median"], ["mean", "Mean"], ["5th-percentile", "5th Percentile"], ["25th-percentile", "25th Percentile"], ["75th-percentile", "75th Percentile"], ["95th-percentile", "95th Percentile"]];
         } else {
-          option = [["mean", "Mean"]];
+          options = [["mean", "Mean"]];
         }
         multiselectSetOptions($("#aggregates"), options, gInitialPageState.aggregates !== undefined && gInitialPageState.aggregates.length > 0 ? gInitialPageState.aggregates : [options[0][0]]);
         
@@ -605,4 +610,11 @@ function saveStateToUrlAndCookie() {
   // Add link to switch to the evolution dashboard with the same settings
   var dashboardURL = window.location.origin + window.location.pathname.replace(/evo\.html$/, "dist.html") + window.location.hash;
   $("#switch-views").attr("href", dashboardURL);
+  
+  // If advanced settings are not at their defaults, display a notice in the panel header
+  if (gInitialPageState.use_submission_date !== 0 || gInitialPageState.sanitize !== 1) {
+    $("#advanced-settings-toggle").find("span").text(" (modified)");
+  } else {
+    $("#advanced-settings-toggle").find("span").text("");
+  }
 }

--- a/src/evo.js
+++ b/src/evo.js
@@ -379,6 +379,7 @@ function displayEvolutions(lines, submissionLines, minDate, maxDate, useSubmissi
   
   var aggregateMap = {};
   lines.forEach(function(line) { aggregateMap[line.aggregate] = true; });
+  var variableLabel = useSubmissionDate ? "Submission Date" : "Build ID";
   var valueLabel = Object.keys(aggregateMap).sort().join(", ") + " " + (lines.length > 0 ? lines[0].measure : "");
   
   var markers = [], usedDates = {};
@@ -400,7 +401,7 @@ function displayEvolutions(lines, submissionLines, minDate, maxDate, useSubmissi
     right: 100, bottom: 50, // Extra space on the right and bottom for labels
     target: "#evolutions",
     x_extended_ticks: true,
-    x_label: "Build ID", y_label: valueLabel,
+    x_label: variableLabel, y_label: valueLabel,
     transition_on_update: false,
     interpolate: "linear",
     markers: markers, legend: aggregateLabels,


### PR DESCRIPTION
* The advanced settings panel will now show "(modified)" when we change advanced settings, and open on load.
* It is no longer possible to select versions that are in different channels in evolution dashboard, like beta to nightly.
* The X-axis label now changes along with the evolution variable.
* Bugfixes for switching between aggregates of different kinds - switching to a flag histogram should automatically select the Mean aggregate, even when it was not previously selected.

Now live on http://production.telemetry-dashboard.divshot.io/