### PR TITLE
Various fixes from #97

### DIFF
--- a/dist.html
+++ b/dist.html
@@ -89,6 +89,11 @@
                         <div class="panel-body">
                             <form class="form-horizontal">
                                 <div>
+                                    <b>Table mode:</b> show histograms as tables of values rather than visual charts:
+                                    <label><input name="table-toggle" type="radio" value="0"> Show histograms</label>
+                                    <label><input name="table-toggle" type="radio" value="1"> Show tables</label>
+                                </div>
+                                <div>
                                     Cumulative mode: show each bucket as the sum of itself and all buckets on its left:
                                     <label><input name="cumulative-toggle" type="radio" value="0"> Non-cumulative</label>
                                     <label><input name="cumulative-toggle" type="radio" value="1"> Cumulative</label>

--- a/new-pipeline/src/dist.js
+++ b/new-pipeline/src/dist.js
@@ -500,6 +500,8 @@ function displayHistograms(histogramsList, dates, useTable, cumulative, trim) {
 }
 
 function displaySingleHistogramSet(axes, useTable, histograms, title, cumulative, trimLeft, trimRight, maxPercentage) {
+  $(axes).empty(); // Remove tables if they are present
+
   // No histograms available
   if (histograms.length === 0) {
     MG.data_graphic({
@@ -539,7 +541,6 @@ function displaySingleHistogramSet(axes, useTable, histograms, title, cumulative
     displaySingleHistogramTableSet(axes, starts, ends, countsList, histograms);
     return;
   }
-  $(axes).empty(); // Remove tables if they are present
   
   var distributionSamples = countsList.map(function(counts, i) {
     return counts.map(function(count, j) { return {value: j, count: (count / histograms[i].count) * 100}; });

--- a/src/dashboards.js
+++ b/src/dashboards.js
@@ -131,6 +131,7 @@ function loadStateFromUrlAndCookie() {
     pageState.os = pageState.arch = pageState.e10s = pageState.processType = null;
     pageState.use_submission_date = 0;
     pageState.sanitize = 1;
+    pageState.table = 0;
     pageState.cumulative = 0;
     pageState.start_date = pageState.end_date = null;
     return pageState;
@@ -167,6 +168,7 @@ function loadStateFromUrlAndCookie() {
   
   pageState.use_submission_date = pageState.use_submission_date === "0" || pageState.use_submission_date === "1" ? parseInt(pageState.use_submission_date) : 0;
   pageState.sanitize = pageState.sanitize === "0" || pageState.sanitize === "1" ? parseInt(pageState.sanitize) : 1;
+  pageState.table = pageState.table === "0" || pageState.table === "1" ? parseInt(pageState.table) : 0;
   pageState.cumulative = pageState.cumulative === "0" || pageState.cumulative === "1" ? parseInt(pageState.cumulative) : 0;
   pageState.trim = pageState.trim === "0" || pageState.trim === "1" ? parseInt(pageState.trim) : 1;
   pageState.start_date = typeof pageState.start_date === "string" && /\d{4}-\d{2}-\d{2}/.test(pageState.start_date) ? pageState.start_date : null;


### PR DESCRIPTION
* Don't hardcode max version - default to latest nightly.
* When changing sort order of keys in a keyed histogram, reset the four distribution graphs to the top 4 again.
* Filter out version numbers that seem to be too high in the version selector in the evolution dash.
* Apply settings such as cumulative-ness to the export files.
* Pretty-print the JSON in export files.
* More contrast for the lines in graphs.
* Limit select-all select single option behaviour to product and OS selectors (elsewhere, they are confusing to use).
* Use shorter names for OS selector tooltip.
* Improve the product list display.

These changes have been applied to both the v2 and v4 dashboards. The changes are live at http://production.telemetry-dashboard.divshot.io/.