### PR TITLE
Use HTTPS links where possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 Telemetry Dashboard
 ===================
 
-This repository contains the **source code for [telemetry.mozilla.org](http://telemetry.mozilla.org)**. The dashboards on this site can be used for everything from checking measure values to figuring out common causes of Firefox hangs.
+This repository contains the **source code for [telemetry.mozilla.org](https://telemetry.mozilla.org)**. The dashboards on this site can be used for everything from checking measure values to figuring out common causes of Firefox hangs.
 
-The main dashboards on [telemetry.mozilla.org](http://telemetry.mozilla.org) consume data from Telemetry's v2 and v4 backends using Telemetry.js. For an overview of how all these systems fit together, see [Telemetry Demystified](http://anthony-zhang.me/blog/telemetry-demystified/).
+The main dashboards on [telemetry.mozilla.org](https://telemetry.mozilla.org) consume data from Telemetry's v2 and v4 backends using Telemetry.js. For an overview of how all these systems fit together, see [Telemetry Demystified](https://anthony-zhang.me/blog/telemetry-demystified/).
 
-The dashboards that do not use Telemetry.js generally use [scheduled analysis jobs](http://telemetry-dash.mozilla.org/) that regularly publish data on S3. The source code for these can be found in their respective repositories.
+The dashboards that do not use Telemetry.js generally use [scheduled analysis jobs](https://telemetry-dash.mozilla.org/) that regularly publish data on S3. The source code for these can be found in their respective repositories.
 
 This repository also contains the **source code for Telemetry.js** (all versions). The specific files can be found under the `v1/` and `v2/` directories.
 
@@ -14,18 +14,18 @@ We currently have two versions of the Histogram Dashboard and Evolution Dashboar
 Deploying Telemetry Dashboard
 -----------------------------
 
-The [telemetry.mozilla.org](http://telemetry.mozilla.org) site is hosted on S3, in the [telemetry.mozilla.org bucket](https://console.aws.amazon.com/s3/home#&bucket=telemetry.mozilla.org). In front of S3, there is also the CloudFront CDN (managed by :mostlygeek).
+The [telemetry.mozilla.org](https://telemetry.mozilla.org) site is hosted on S3, in the [telemetry.mozilla.org bucket](https://console.aws.amazon.com/s3/home#&bucket=telemetry.mozilla.org). In front of S3, there is also the CloudFront CDN (managed by :mostlygeek).
 
 The contents of this bucket are uploaded from the telemetry dashboard master node instance on AWS. The currently active dashboard master node is `ec2-54-202-211-22.us-west-2.compute.amazonaws.com`. On the node, there is a script `~/update-telemetry.mozilla.org.sh`, run by cron every day, that pulls the latest master for telemetry-dashboard from the GitHub repository and uploads it to the S3 bucket using the `aws s3 sync . s3://telemetry.mozilla.org/ --delete --region us-east-1 --exclude ".*"` command.
 
-In effect, [telemetry.mozilla.org](http://telemetry.mozilla.org) is updated daily from the Git repository. To do a manual deploy (useful if there's a change that needs to be pushed out quickly), SSH into `ubuntu@ec2-54-202-211-22.us-west-2.compute.amazonaws.com` and manually run `~/update-telemetry.mozilla.org.sh` - the changes will go live almost immediately.
+In effect, [telemetry.mozilla.org](https://telemetry.mozilla.org) is updated daily from the Git repository. To do a manual deploy (useful if there's a change that needs to be pushed out quickly), SSH into `ubuntu@ec2-54-202-211-22.us-west-2.compute.amazonaws.com` and manually run `~/update-telemetry.mozilla.org.sh` - the changes will go live almost immediately.
 
 Using Telemetry.js
 ------------------
 
 Check out the documentation!
 
-* [Telemetry.js v1](http://telemetry.mozilla.org/docs.html)
+* [Telemetry.js v1](https://telemetry.mozilla.org/docs.html)
 * [Telemetry.js v2](https://github.com/mozilla/telemetry-dashboard/blob/master/v2/doc.md)
 
 Adding Telemetry Probes
@@ -33,7 +33,7 @@ Adding Telemetry Probes
 
 See this [MDN article], which outlines the process and details for adding new Telemetry probes to Firefox which can be used with the dashboards.
 
-For setting histogram properties, make sure to check out the [histogram simulator](http://telemetry.mozilla.org/histogram-simulator/), which might help with designing histograms that fit the expected data well.
+For setting histogram properties, make sure to check out the [histogram simulator](https://telemetry.mozilla.org/histogram-simulator/), which might help with designing histograms that fit the expected data well.
 
 Hacking Telemetry Dashboard
 ---------------------------

--- a/index.html
+++ b/index.html
@@ -60,8 +60,8 @@
                 <ul>
                     <li><a href="new-pipeline/tutorial.html">Dashboard v4 usage tutorial</a></li>
                     <li><a href="tutorial.html">Dashboard v2 usage tutorial</a></li>
-                    <li><a href="http://anthony-zhang.me/blog/telemetry-demystified/">What is Telemetry?</a></li>
-                    <li><a href="https://air.mozilla.org/azhang/">Zen and the Art of Telemetry</a> (<a href="http://telemetry.mozilla.org/art-of-telemetry.pdf">Slides</a>)</li>
+                    <li><a href="https://anthony-zhang.me/blog/telemetry-demystified/">What is Telemetry?</a></li>
+                    <li><a href="https://air.mozilla.org/azhang/">Zen and the Art of Telemetry</a> (<a href="art-of-telemetry.pdf">Slides</a>)</li>
                     <li><a href="http://robertovitillo.com/2015/01/16/next-gen-data-analysis-framework-for-telemetry/">How to do custom Telemetry analyses</a></li>
                     <li><a href="https://wiki.mozilla.org/Platform/GFX/Telemetry">How to do GFX Telemetry analyses</a></li>
                     <li><a href="https://github.com/mozilla/telemetry-dashboard/blob/master/v2/doc.md"><code>telemetry.js</code> v2 documentation</a></li>
@@ -94,10 +94,10 @@
             <div class="col-md-4">
                 <h3>Other dashboards</h3>
                 <div class="dashboard-list scrollable-dashboard-list list-group">
-                    <a class="list-group-item" href="http://mozilla.github.io/iacomus/resources/public/index.html#?config=https://s3-us-west-2.amazonaws.com/telemetry-public-analysis/Addon+analysis/data/startup.json">
+                    <a class="list-group-item" href="https://mozilla.github.io/iacomus/resources/public/index.html#?config=https://s3-us-west-2.amazonaws.com/telemetry-public-analysis/Addon+analysis/data/startup.json">
                         Addon Startup Correlations <div class="dashboard-description">Analyze the impact of addons on startup time.</div>
                     </a>
-                    <a class="list-group-item" href="http://mozilla.github.io/iacomus/resources/public/index.html#?config=https://s3-us-west-2.amazonaws.com/telemetry-public-analysis/Addon+analysis/data/shutdown.json">
+                    <a class="list-group-item" href="https://mozilla.github.io/iacomus/resources/public/index.html#?config=https://s3-us-west-2.amazonaws.com/telemetry-public-analysis/Addon+analysis/data/shutdown.json">
                         Addon Shutdown Correlations <div class="dashboard-description">Analyze the impact of addons on shutdown time.</div>
                     </a>
                     <a class="list-group-item" href="hang/bhr">
@@ -106,19 +106,19 @@
                     <a class="list-group-item" href="chromehangs">
                         Chrome Hangs <div class="dashboard-description">View common hang stacks in Firefox Nightly.</div>
                     </a>
-                    <a class="list-group-item" href="http://bsmedberg.github.io/telemetry-experiments-dashboard/">
+                    <a class="list-group-item" href="https://bsmedberg.github.io/telemetry-experiments-dashboard/">
                         Experiment Monitoring <div class="dashboard-description">View vitals and statistics for Firefox Telemetry Experiments.</div>
                     </a>
                     <a class="list-group-item" href="hang/anr">
                         Fennec App Not Responding (ANR) <div class="dashboard-description">Analyze sources of hangs as reported by the ANR service.</div>
                     </a>
-                    <a class="list-group-item" href="http://mozilla.github.io/iacomus/resources/public/index.html#?config=https://s3-us-west-2.amazonaws.com/telemetry-public-analysis/mainthreadio/data/iacomus.json">
+                    <a class="list-group-item" href="https://mozilla.github.io/iacomus/resources/public/index.html#?config=https://s3-us-west-2.amazonaws.com/telemetry-public-analysis/mainthreadio/data/iacomus.json">
                         Main Thread I/O <div class="dashboard-description">View time taken by I/O operations on the main thread.</div>
                     </a>
                     <a class="list-group-item" href="distribution">
                         Population Distribution <div class="dashboard-description">View distribution of OS, architecture, etc. for Firefox users.</div>
                     </a>
-                    <a class="list-group-item" href="http://people.mozilla.org/~rvitillo/dashboard/">
+                    <a class="list-group-item" href="https://people.mozilla.org/~rvitillo/dashboard/">
                         Power Dashboard <span class="label label-warning" style="font-size: 12px">DRAFT</span> <div class="dashboard-description">View and compare power consumption for various websites, between browsers.</div>
                     </a>
                     <a class="list-group-item" href="slowsql">
@@ -133,7 +133,7 @@
                     <a class="list-group-item" href="https://useradvocacy.mozilla.org/dashboards/telemetry-ui/">
                         Firefox UI Telemetry <div class="dashboard-description">View aggregate UI events and configurations for Firefox.</div>
                     </a>
-                    <a class="list-group-item" href="http://people.mozilla.org/~danderson/moz-gfx-telemetry/www/">
+                    <a class="list-group-item" href="https://people.mozilla.org/~danderson/moz-gfx-telemetry/www/">
                         Graphics Telemetry <div class="dashboard-description">View percentage breakdowns for various graphics features.</div>
                     </a>
                 </div>

--- a/v2/doc.md
+++ b/v2/doc.md
@@ -1,9 +1,9 @@
 Telemetry.js (v2)
 =================
 
-Telemetry.js v2 is a Javascript library for accessing v4 pipeline data from [Mozilla Telemetry](http://telemetry.mozilla.org/). This library powers the v4 pipeline dashboards on Mozilla Telemetry.
+Telemetry.js v2 is a Javascript library for accessing v4 pipeline data from [Mozilla Telemetry](https://telemetry.mozilla.org/). This library powers the v4 pipeline dashboards on Mozilla Telemetry.
 
-Not familiar with Mozilla Telemetry? Check out this [high-level overview](http://anthony-zhang.me/blog/telemetry-demystified/).
+Not familiar with Mozilla Telemetry? Check out this [high-level overview](https://anthony-zhang.me/blog/telemetry-demystified/).
 
 The main purpose of this library is to provide access to the evolution of histograms over time and buildID, for various types of measures and various combinations of filters.
 
@@ -14,7 +14,7 @@ Setup
 
 Simply add this to your HTML:
 
-    <script src="http://anthony-zhang.me/telemetry-dashboard/v2/telemetry.js"></script>
+    <script src="https://telemetry.mozilla.org/v2/telemetry.js"></script>
 
 The global `Telemetry` object will now be available for use in subsequently executed Javascript code. The library also supports the CommonJS module format.
 

--- a/v2/telemetry.js
+++ b/v2/telemetry.js
@@ -7,7 +7,7 @@ function assert(condition, message) {
 }
 
 var Telemetry = {
-  BASE_URL: 'http://aggregates.telemetry.mozilla.org/',
+  BASE_URL: 'https://aggregates.telemetry.mozilla.org/',
   CHANNEL_VERSION_DATES: null,
   CHANNEL_VERSION_BUILDIDS: null,
   CACHE: {}, CACHE_LAST_UPDATED: {}, CACHE_TIMEOUT: 4 * 60 * 60 * 1000,


### PR DESCRIPTION
Some sites still don't work with HTTPS, such as Telemetry Alerts.

Also, use the correct URL for the Telemetry.js include in the Telemetry.js v2 documentation.

**NOTE:** do not merge until https://bugzilla.mozilla.org/show_bug.cgi?id=1195802 is resolved.