### PR TITLE
Revert "Change BASE_URL from http to https"

### DIFF
--- a/v2/telemetry.js
+++ b/v2/telemetry.js
@@ -7,7 +7,7 @@ function assert(condition, message) {
 }
 
 var Telemetry = {
-  BASE_URL: 'https://aggregates.telemetry.mozilla.org/',
+  BASE_URL: 'http://aggregates.telemetry.mozilla.org/',
   CHANNEL_VERSION_DATES: null,
   CHANNEL_VERSION_BUILDIDS: null,
   CACHE: {}, CACHE_LAST_UPDATED: {}, CACHE_TIMEOUT: 4 * 60 * 60 * 1000,


### PR DESCRIPTION
Commit b1140960d72c9e9624a512875b366fbad529666c needs to be temporarily reverted until [this bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1195802) is fixed.

These changes are already included in #125, so when the bug is fixed, merging #125 will include the changes that were originally made in this commit.