### PR TITLE
Make resizing work properly with dynamic plot aspect ratio.

### DIFF
--- a/new-pipeline/src/dist.js
+++ b/new-pipeline/src/dist.js
@@ -168,10 +168,17 @@ $(function() { Telemetry.init(function() {
     $("#measure").trigger("change");
   });
   
-  // Automatically resize range bar
+  var resizeUpdateTimeout = null;
   $(window).resize(function() {
+    // Automatically resize range bar
     var dateControls = $("#date-range-controls");
     $("#range-bar").outerWidth(dateControls.parent().width() - dateControls.outerWidth() - 10);
+    
+    // Resize the main plot (MetricsGraphics has a full_width option, but that breaks zooming for plots)
+    if (resizeUpdateTimeout !== null) { clearTimeout(resizeUpdateTimeout); }
+    resizeUpdateTimeout = setTimeout(function() {
+      $("#selected-key1").trigger("change");
+    }, 50);
   });
   $("#advanced-settings").on("shown.bs.collapse", function () {
     var dateControls = $("#date-range-controls");
@@ -509,7 +516,8 @@ function displaySingleHistogramSet(axes, useTable, histograms, title, cumulative
   if (histograms.length === 0) {
     MG.data_graphic({
       chart_type: "missing-data",
-      full_width: true, height: $(axes).width() * 0.6,
+      width: $(axes).parent().width(), // We can't use the full_width option of MetricsGraphics because that breaks page zooming for graphs
+      height: 600,
       target: axes,
     });
     $(axes).find(".mg-missing-pane").remove();
@@ -556,7 +564,8 @@ function displaySingleHistogramSet(axes, useTable, histograms, title, cumulative
       data: distributionSamples[0],
       binned: true,
       chart_type: "histogram",
-      full_width: true, height: $(axes).width() * 0.6,
+      width: $(axes).parent().width(), // We can't use the full_width option of MetricsGraphics because that breaks page zooming for graphs
+      height: 600,
       top: 0, left: 70, right: $(axes).width() / (distributionSamples[0].length + 1),
       max_y: maxPercentage,
       transition_on_update: false,
@@ -620,7 +629,8 @@ function displaySingleHistogramSet(axes, useTable, histograms, title, cumulative
     MG.data_graphic({
       data: distributionSamples,
       chart_type: "line",
-      full_width: true, height: $(axes).width() * 0.6,
+      width: $(axes).parent().width(), // We can't use the full_width option of MetricsGraphics because that breaks page zooming for graphs
+      height: 600,
       left: 70,
       max_y: maxPercentage + 2, // Add some extra space to account for the bezier curves
       transition_on_update: false,

--- a/new-pipeline/src/evo.js
+++ b/new-pipeline/src/evo.js
@@ -183,7 +183,15 @@ $(function() { Telemetry.init(function() {
     // Perform a full display refresh
     $("#measure").trigger("change");
   });
-  
+
+  var resizeUpdateTimeout = null;
+  $(window).resize(function() {
+    // Resize the main plot (MetricsGraphics has a full_width option, but that breaks zooming for plots)
+    if (resizeUpdateTimeout !== null) { clearTimeout(resizeUpdateTimeout); }
+    resizeUpdateTimeout = setTimeout(function() {
+      $("#selected-key").trigger("change");
+    }, 50);
+  });
   $("#advanced-settings").on("shown.bs.collapse", function () {
     $(this).get(0).scrollIntoView({behavior: "smooth"}); // Scroll the advanced settings into view when opened
   });
@@ -368,7 +376,8 @@ function displayEvolutions(lines, submissionLines, useSubmissionDate) {
   MG.data_graphic({
     data: lineData,
     chart_type: lineData.length == 0 || lineData[0].length === 0 ? "missing-data" : "line",
-    full_width: true, height: 600,
+    width: $("#evolutions").parent().width(), // We can't use the full_width option of MetricsGraphics because that breaks page zooming for graphs
+    height: 600,
     right: 100, bottom: 50, // Extra space on the right and bottom for labels
     target: "#evolutions",
     x_extended_ticks: true,
@@ -426,7 +435,8 @@ function displayEvolutions(lines, submissionLines, useSubmissionDate) {
   MG.data_graphic({
     data: submissionLineData,
     chart_type: submissionLineData.length === 0 || submissionLineData[0].length === 0 ? "missing-data" : "line",
-    full_width: true, height: 300,
+    width: $("#submissions").parent().width(), // We can't use the full_width option of MetricsGraphics because that breaks page zooming for graphs
+    height: 300,
     right: 100, bottom: 50, // Extra space on the right and bottom for labels
     target: "#submissions",
     x_extended_ticks: true,

--- a/src/dist.js
+++ b/src/dist.js
@@ -92,15 +92,17 @@ Telemetry.init(function() {
     saveStateToUrlAndCookie();
   });
 
-  // Automatically resize range bar
+  var resizeUpdateTimeout = null;
   $(window).resize(function() {
+    // Automatically resize range bar
     var dateControls = $("#date-range-controls");
     $("#range-bar").outerWidth(dateControls.parent().width() - dateControls.outerWidth() - 10);
-  });
-  $("#advanced-settings").on("shown.bs.collapse", function () {
-    var dateControls = $("#date-range-controls");
-    $("#range-bar").outerWidth(dateControls.parent().width() - dateControls.outerWidth() - 10);
-    $(this).get(0).scrollIntoView({behavior: "smooth"}); // Scroll the advanced settings into view when opened
+    
+    // Resize the main plot (MetricsGraphics has a full_width option, but that breaks zooming for plots)
+    if (resizeUpdateTimeout !== null) { clearTimeout(resizeUpdateTimeout); }
+    resizeUpdateTimeout = setTimeout(function() {
+      $("input[name=table-toggle]").trigger("change");
+    }, 50);
   });
 });
 
@@ -419,7 +421,8 @@ function displayHistogram(histogram, dates, useTable, cumulative, trim) {
     data: distributionSamples,
     binned: true,
     chart_type: "histogram",
-    full_width: true, height: 600,
+    width: $(axes).parent().width(), // We can't use the full_width option of MetricsGraphics because that breaks page zooming for graphs
+    height: 600,
     left: 150, right: $(axes).width() / (distributionSamples.length + 1),
     transition_on_update: false,
     target: "#distribution",

--- a/src/evo.js
+++ b/src/evo.js
@@ -164,6 +164,14 @@ Telemetry.init(function() {
     });
   });
 
+  var resizeUpdateTimeout = null;
+  $(window).resize(function() {
+    // Resize the main plot (MetricsGraphics has a full_width option, but that breaks zooming for plots)
+    if (resizeUpdateTimeout !== null) { clearTimeout(resizeUpdateTimeout); }
+    resizeUpdateTimeout = setTimeout(function() {
+      $("#aggregates").trigger("change");
+    }, 500);
+  });
   $("#advanced-settings").on("shown.bs.collapse", function () {
     $(this).get(0).scrollIntoView({behavior: "smooth"}); // Scroll the advanced settings into view when opened
   });
@@ -459,7 +467,8 @@ function displayEvolutions(lines, submissionLines, minDate, maxDate, useSubmissi
   MG.data_graphic({
     data: lineData,
     chart_type: lineData.length == 0 || lineData[0].length === 0 ? "missing-data" : "line",
-    full_width: true, height: 600,
+    width: $("#evolutions").parent().width(), // We can't use the full_width option of MetricsGraphics because that breaks page zooming for graphs
+    height: 600,
     right: 100, bottom: 50, // Extra space on the right and bottom for labels
     target: "#evolutions",
     x_extended_ticks: true,
@@ -520,7 +529,8 @@ function displayEvolutions(lines, submissionLines, minDate, maxDate, useSubmissi
   MG.data_graphic({
     data: submissionLineData,
     chart_type: submissionLineData.length === 0 || submissionLineData[0].length === 0 ? "missing-data" : "line",
-    full_width: true, height: 300,
+    width: $("#submissions").parent().width(), // We can't use the full_width option of MetricsGraphics because that breaks page zooming for graphs
+    height: 300,
     right: 100, bottom: 50, // Extra space on the right and bottom for labels
     target: "#submissions",
     x_extended_ticks: true,


### PR DESCRIPTION
Right now, when dashboard pages are resized the aspect ratio of the plot remains the same, which makes things look weird when zooming the page.

By avoiding the `full_width` option, we can manually calculate the chart size to get a smoother result.

Now live at http://staging.telemetry-dashboard.divshot.io/.