### PR TITLE
Fixes and features

### DIFF
--- a/new-pipeline/src/dist.js
+++ b/new-pipeline/src/dist.js
@@ -262,8 +262,8 @@ function calculateHistograms(callback, sanitize) {
           filterSetsCount ++;
           for (var label in fullEvolutionMap) { // Make a list of evolutions and option labels for each label in the evolution
             if (sanitize) { fullEvolutionMap[label] = fullEvolutionMap[label].sanitized(); }
+            if (!fullEvolutionsMap.hasOwnProperty(label)) { fullEvolutionsMap[label] = []; }
             if (fullEvolutionMap[label] !== null) {
-              if (!fullEvolutionsMap.hasOwnProperty(label)) { fullEvolutionsMap[label] = []; }
               fullEvolutionsMap[label].push(fullEvolutionMap[label]);
             }
             if (!optionValues.hasOwnProperty(label)) { optionValues[label] = []; }
@@ -275,7 +275,9 @@ function calculateHistograms(callback, sanitize) {
             // Get the set union of all the dates in all the evolutions
             var datesMap = {};
             for (var label in fullEvolutionsMap) {
-              fullEvolutionsMap[label][0].dates().forEach(function(date) { datesMap[date.getTime()] = true; });
+              if (fullEvolutionsMap[label].length > 0) {
+                fullEvolutionsMap[label][0].dates().forEach(function(date) { datesMap[date.getTime()] = true; });
+              }
             }
             var dates = Object.keys(datesMap).map(function(dateString) {
               return new Date(parseInt(dateString));

--- a/new-pipeline/src/dist.js
+++ b/new-pipeline/src/dist.js
@@ -826,8 +826,9 @@ function displaySingleHistogramTableSet(axes, starts, ends, countsList, histogra
                 $("<td></td>").text(formatNumber(starts[i])),
                 $("<td></td>").text(formatNumber(ends[i])),
               ].concat(
-                countsList.map(function(counts) {
-                  return $("<td></td>").text(formatNumber(counts[i]));
+                countsList.map(function(counts, j) {
+                  var percentage = Math.round(10000 * counts[i] / histograms[j].count) / 100;
+                  return $("<td></td>").text(formatNumber(counts[i]) + " (" + percentage + "%)");
                 })
               )
             )

--- a/new-pipeline/src/dist.js
+++ b/new-pipeline/src/dist.js
@@ -290,6 +290,9 @@ function calculateHistograms(callback, sanitize) {
                         histogram.measure = humanReadableOption;
                       }
                       return histogram;
+                    }).sort(function(histogram1, histogram2) {
+                      return histogram1.measure < histogram2.measure ?
+                        -1 : (histogram1.measure > histogram2.measure ? 1 : 0);
                     });
                   }
                 }

--- a/new-pipeline/src/dist.js
+++ b/new-pipeline/src/dist.js
@@ -574,6 +574,13 @@ function displaySingleHistogramSet(axes, useTable, histograms, title, cumulative
       return counts.map(function(count) { return total += count; });
     });
   }
+
+  if (useTable) { // Display the histogram as a table rather than a chart
+    displaySingleHistogramTableSet(axes, starts, ends, countsList, histograms);
+    return;
+  }
+
+  // Apply bucket trimming
   while (trimLeft) {
     starts.shift(); ends.shift();
     countsList.forEach(function(counts) { counts.shift(); });
@@ -583,11 +590,6 @@ function displaySingleHistogramSet(axes, useTable, histograms, title, cumulative
     starts.pop(); ends.pop();
     countsList.forEach(function(counts) { counts.pop(); });
     trimRight --;
-  }
-
-  if (useTable) { // Display the histogram as a table rather than a chart
-    displaySingleHistogramTableSet(axes, starts, ends, countsList, histograms);
-    return;
   }
   
   var distributionSamples = countsList.map(function(counts, i) {

--- a/new-pipeline/src/dist.js
+++ b/new-pipeline/src/dist.js
@@ -638,9 +638,11 @@ function displaySingleHistogramSet(axes, useTable, histograms, title, cumulative
         var count = formatNumber(countsList[0][d.x]), percentage = Math.round(d.y * 100) / 100 + "%";
         var label;
         if (ends[d.x] === Infinity) {
-         label = "sample value \u2265 " + formatNumber(cumulative ? 0 : starts[d.x]);
+          label = "sample value \u2265 " + formatNumber(cumulative ? 0 : starts[d.x]);
+        } else if (histogram.kind === "enumerated") {
+          label = "sample value" + (cumulative ? " \u2264 " : " is ") + formatNumber(starts[d.x]);
         } else {
-         label = formatNumber(cumulative ? 0 : starts[d.x]) + " \u2264 sample value < " + formatNumber(ends[d.x]);
+          label = formatNumber(cumulative ? 0 : starts[d.x]) + " \u2264 sample value < " + formatNumber(ends[d.x]);
         }
 
         var offset = $(axes).find(".mg-bar:nth-child(" + (i + 1) + ")").get(0).getAttribute("transform");
@@ -742,11 +744,14 @@ function displaySingleHistogramSet(axes, useTable, histograms, title, cumulative
             color: colors[d.line_id - 1],
           }];
         }
-        var labelValue = (
-          end === Infinity ?
-          "sample value \u2265 " + formatNumber(cumulative ? 0 : start) :
-          formatNumber(cumulative ? 0 : start) + " \u2264 sample value < " + formatNumber(end)
-        ) + ":";
+        var labelValue;
+        if (end === Infinity) {
+          labelValue = "sample value \u2265 " + formatNumber(cumulative ? 0 : start) + ":";
+        } else if (histograms[0].kind === "enumerated") {
+          labelValue = "sample value" + (cumulative ? " \u2264 " : " is ") + formatNumber(start) + ":";
+        } else {
+          labelValue = formatNumber(cumulative ? 0 : start) + " \u2264 sample value < " + formatNumber(end) + ":";
+        }
         var legend = d3.select(axes).select(".mg-active-datapoint").text(labelValue).style("fill", "white");
         var lineHeight = 1.1;
         entries.forEach(function(entry, i) {

--- a/new-pipeline/tutorial.html
+++ b/new-pipeline/tutorial.html
@@ -41,6 +41,8 @@
                     <dd>A summarizing, single numerical value for a histogram, such as the mean or median. Histograms have one of each aggregate, while evolutions can have many - one for each histogram they contain.</dd>
                     <dt>Measure/Metric</dt>
                     <dd>A value that can be measured via Telemetry, such as the number of milliseconds used in each garbage collection cycle in Firefox (GC_MS). Since there are a lot of these values, we generally only want to see their aggregates, such as their average.</dd>
+                    <dt>Keyed Measure</dt>
+                    <dd>A type of measure that associates keys (strings) to sub-measures, such as addon exceptions associated with the number of times those exceptions are thrown (JS_TELEMETRY_ADDON_EXCEPTIONS). Each sub-measure has their own aggregates and histograms.</dd>
                     <dt>Sample</dt>
                     <dd>A single reading for a measure. Generally, we only care about the number of these that fall within a certain range, not the sample values themselves.</dd>
                     <dt>Submission/Ping</dt>

--- a/src/dist.js
+++ b/src/dist.js
@@ -396,7 +396,12 @@ function displayHistogram(histogram, dates, useTable, cumulative, trim) {
   var ends = histogram.map(function(count, start, end, i) { return end; });
   ends[ends.length - 1] = Infinity;
   var totalCount = histogram.count();
-  
+
+  if (useTable) { // Display the histogram as a table rather than a chart
+    displayHistogramTable(starts, ends, counts, histogram);
+    return;
+  }
+
   if (trim) { // Trim buckets on both ends in the histogram if their counts are too low
     // Histograms need at least 3 buckets to render properly, so make sure not to trim off too much
     var countCutoff = totalCount * 0.0001; // Set the samples cutoff to 0.01% of the total samples
@@ -406,11 +411,6 @@ function displayHistogram(histogram, dates, useTable, cumulative, trim) {
     while (counts[counts.length - 1] < countCutoff && counts.length > 3) {
       counts.pop(); starts.pop(); ends.pop();
     }
-  }
-  
-  if (useTable) { // Display the histogram as a table rather than a chart
-    displayHistogramTable(starts, ends, counts, histogram);
-    return;
   }
   
   var distributionSamples = counts.map(function(count, i) { return {value: i, count: (count / totalCount) * 100}; });

--- a/v2/doc.md
+++ b/v2/doc.md
@@ -70,6 +70,16 @@ Telemetry.init(function() {
 });
 ```
 
+Getting the available keys in the keyed histogram JS_TELEMETRY_ADDON_EXCEPTIONS on nightly 42:
+
+```javascript
+Telemetry.init(function() {
+    Telemetry.getEvolution("nightly", "42", "JS_TELEMETRY_ADDON_EXCEPTIONS", {}, true, function(evolutionMap) {
+        console.log("JS_TELEMETRY_ADDON_EXCEPTIONS keys:\n" + Object.keys(evolutionMap).sort().join("\n"));
+    });
+});
+```
+
 API Reference
 -------------
 


### PR DESCRIPTION
* Don't trim buckets for table view, and sort comparison measures (#136, #137).
* Add a (none) option for keys so we have something to display when there are fewer than 4 available keys (#139).
* Don't sanitize key list for histograms - always show all of the keys regardless of how many submissions they have (#138).
* Add an example and description for keyed histograms (#140). Keyed histogram support is already documented for Telemetry.js v2 in the API reference.
* Make the labels for enumerated histograms the bucket range values themselves, rather than a range of values (#142).

Now live at http://staging.telemetry-dashboard.divshot.io/.
