### PR TITLE
bug 1219790 - Accept a &bare=true parameter for no-frills viewing. r?vladan

### DIFF
--- a/new-pipeline/dist.html
+++ b/new-pipeline/dist.html
@@ -19,7 +19,7 @@
 </head>
 <body>
     <div class="container-fluid">
-        <header>
+        <header class="dashboard-header">
             <form class="navbar-form inline pull-right">
                 <a href="https://github.com/mozilla/telemetry-dashboard/issues" class="btn btn-success" title="Report a bug in Telemetry dashboards" target="_blank">Report bug</a>
                 <a href="./evo.html" class="btn btn-default" id="switch-views" title="Switch to the evolution view">Evolution View</a>
@@ -31,7 +31,7 @@
         </header>
         <div class="row">
             <div class="col-md-12">
-                <h2 style="font-size: 18px; margin-bottom: 0">
+                <h2 class="query-string">
                     <span style="font-weight: bold">
                         <select id="measure" class="multiselect" title="Value being measured"></select>
                         distribution for
@@ -60,33 +60,25 @@
                         <div class="row">
                             <div class="col-md-6" style="text-align: center">
                                 <h3><select id="selected-key1" class="multiselect" title="Selected key"></select></h3>
-                                <div style="margin-bottom: 20px; z-index: -1">
-                                    <div id="distribution1"></div>
-                                </div>
+                                <div class="distribution" id="distribution1"></div>
                             </div>
                             <div class="col-md-6" style="text-align: center">
                                 <h3><select id="selected-key2" class="multiselect" title="Selected key"></select></h3>
-                                <div style="margin-bottom: 20px; z-index: -1">
-                                    <div id="distribution2"></div>
-                                </div>
+                                <div class="distribution" id="distribution2"></div>
                             </div>
                         </div>
                         <div class="row">
                             <div class="col-md-6" style="text-align: center">
                                 <h3><select id="selected-key3" class="multiselect" title="Selected key"></select></h3>
-                                <div style="margin-bottom: 20px; z-index: -1">
-                                    <div id="distribution3"></div>
-                                </div>
+                                <div class="distribution" id="distribution3"></div>
                             </div>
                             <div class="col-md-6" style="text-align: center">
                                 <h3><select id="selected-key4" class="multiselect" title="Selected key"></select></h3>
-                                <div style="margin-bottom: 20px; z-index: -1">
-                                    <div id="distribution4"></div>
-                                </div>
+                                <div class="distribution" id="distribution4"></div>
                             </div>
                         </div>
                     </div>
-                    <div class="col-md-3" style="padding-top: 7em">
+                    <div class="figure-info col-md-3" style="padding-top: 7em">
                         <div id="summary">
                             <dl class="dl-horizontal" style="margin-top: 1em">
                                 <dt title="The type of the histogram (e.g., linear, exponential, Boolean)">Histogram Type</dt><dd id="prop-kind"></dd>
@@ -118,7 +110,7 @@
                 </figure>
             </div>
         </div>
-        <div class="row">
+        <div class="advanced-settings-section row">
             <div class="col-md-12">
                 <div class="panel panel-default">
                     <div class="panel-heading" role="tab">
@@ -177,7 +169,7 @@
                 </div>
             </div>
         </div>
-        <div class="row">
+        <div class="comments-footer row">
             <div class="col-md-12">
                 <p class="bg-primary" style="padding: 1em">Make sure to <b>post a permalink</b> if referencing a particular configuration! Comments are associated with the selected measure.</p>
                 <div id="disqus_thread"></div>

--- a/new-pipeline/evo.html
+++ b/new-pipeline/evo.html
@@ -18,7 +18,7 @@
 </head>
 <body>
     <div class="container-fluid">
-        <header>
+        <header class="dashboard-header">
             <form class="navbar-form inline pull-right">
                 <a href="https://github.com/mozilla/telemetry-dashboard/issues" class="btn btn-success" title="Report a bug in Telemetry dashboards" target="_blank">Report bug</a>
                 <a href="./dist.html" class="btn btn-default" id="switch-views" title="Switch to the distribution view">Distribution View</a>
@@ -28,9 +28,9 @@
             </form>
             <h1>Evolution Dashboard V4</h1>
         </header>
-        <div class="row">
+        <div class="evolution-container row">
             <div class="col-md-12">
-                <h2 style="font-size: 18px; margin-bottom: 0">
+                <h2 class="query-string">
                     <span style="font-weight: bold">
                         <select id="aggregates" class="multiselect" title="Aggregate type" data-all-selected="All aggregates of" multiple>
                             <option value="median">Median</option>
@@ -67,7 +67,7 @@
                 </figure>
             </div>
         </div>
-        <div class="row">
+        <div class="advanced-settings-section row">
             <div class="col-md-12">
                 <div class="panel panel-default">
                     <div class="panel-heading" role="tab">
@@ -92,7 +92,7 @@
                 </div>
             </div>
         </div>
-        <div class="row">
+        <div class="comments-footer row">
             <div class="col-md-12">
                 <p class="bg-primary" style="padding: 1em">Make sure to <b>post a permalink</b> if referencing a particular configuration! Comments are associated with the selected measure.</p>
                 <div id="disqus_thread"></div>

--- a/new-pipeline/src/dashboards.js
+++ b/new-pipeline/src/dashboards.js
@@ -314,6 +314,10 @@ function loadStateFromUrlAndCookie() {
     null;
   pageState.end_date = typeof pageState.end_date === "string" &&
     /\d{4}-\d{2}-\d{2}/.test(pageState.end_date) ? pageState.end_date : null;
+
+  if (pageState.bare) {
+    document.body.classList.add('bare');
+  }
   return pageState;
 }
 

--- a/new-pipeline/src/dist.js
+++ b/new-pipeline/src/dist.js
@@ -928,13 +928,11 @@ function displayHistograms(histogramsList, dates, useTable, cumulative, trim) {
     gAxesList.forEach(function (axes) {
       $(axes)
         .parent()
-        .parent()
         .hide();
     });
     $(gAxesList[0])
       .show();
     var axesContainer = $(gAxesList[0])
-      .parent()
       .parent();
     axesContainer.removeClass("col-md-6")
       .addClass("col-md-12")
@@ -961,7 +959,6 @@ function displayHistograms(histogramsList, dates, useTable, cumulative, trim) {
       .addClass("col-md-11");
     gAxesList.forEach(function (axes, i) {
       var axesContainer = $(axes)
-        .parent()
         .parent()
         .show();
       axesContainer.removeClass("col-md-12")
@@ -995,8 +992,10 @@ function displaySingleHistogramSet(axes, useTable, histograms, title,
       chart_type: "missing-data",
       width: $(axes)
         .parent()
+        .parent()
         .width(), // We can't use the full_width option of MetricsGraphics because that breaks page zooming for graphs
       height: 600,
+      full_height: gInitialPageState.bare,
       target: axes,
     });
     $(axes)
@@ -1038,6 +1037,7 @@ function displaySingleHistogramSet(axes, useTable, histograms, title,
       size: {
         canvasHeight: 600,
         canvasWidth: $(axes)
+          .parent()
           .parent()
           .width()
       },
@@ -1137,8 +1137,10 @@ function displaySingleHistogramSet(axes, useTable, histograms, title,
       chart_type: "histogram",
       width: $(axes)
         .parent()
+        .parent()
         .width(), // We can't use the full_width option of MetricsGraphics because that breaks page zooming for graphs
       height: 600,
+      full_height: gInitialPageState.bare,
       top: 0,
       left: 70,
       right: $(axes)
@@ -1273,8 +1275,10 @@ function displaySingleHistogramSet(axes, useTable, histograms, title,
       interpolate: "linear",
       width: $(axes)
         .parent()
+        .parent()
         .width(), // We can't use the full_width option of MetricsGraphics because that breaks page zooming for graphs
       height: 600,
+      full_height: gInitialPageState.bare,
       left: 70,
       max_y: maxPercentage + 2, // Add some extra space to account for the bezier curves
       transition_on_update: false,
@@ -1535,6 +1539,11 @@ function saveStateToUrlAndCookie() {
   // Save a few unused properties that are used in the evolution dashboard, since state is shared between the two dashboards
   if (minChannelVersion !== undefined) {
     gInitialPageState.min_channel_version = minChannelVersion;
+  }
+
+  // save `bare` only if it is true
+  if (document.body.classList.contains('bare')) {
+    gInitialPageState.bare = true;
   }
 
   var selected = $("#compare")

--- a/new-pipeline/src/evo.js
+++ b/new-pipeline/src/evo.js
@@ -787,6 +787,7 @@ function displayEvolutions(lines, submissionLines, useSubmissionDate,
       .parent()
       .width(), // We can't use the full_width option of MetricsGraphics because that breaks page zooming for graphs
     height: 600,
+    full_height: gInitialPageState.bare,
     right: 100,
     bottom: 50, // Extra space on the right and bottom for labels
     target: "#evolutions",
@@ -898,6 +899,7 @@ function displayEvolutions(lines, submissionLines, useSubmissionDate,
       .parent()
       .width(), // We can't use the full_width option of MetricsGraphics because that breaks page zooming for graphs
     height: 300,
+    full_height: gInitialPageState.bare,
     right: 100,
     bottom: 50, // Extra space on the right and bottom for labels
     target: "#submissions",
@@ -1142,6 +1144,11 @@ function saveStateToUrlAndCookie() {
   }
   if (sortKeys !== undefined) {
     gInitialPageState.sort_keys = sortKeys;
+  }
+
+  // Save `bare` only if it is true
+  if (document.body.classList.contains('bare')) {
+    gInitialPageState.bare = true;
   }
 
   // We are guaranteed that selectedKeys is defined by loadStateFromUrlAndCookie

--- a/new-pipeline/style/dashboards.css
+++ b/new-pipeline/style/dashboards.css
@@ -118,3 +118,39 @@
 .mg-line-legend text { font-size: 12px !important; }
 .mg-marker-text { font-size: 12px !important; }
 .mg-markers line { stroke-width: 2px !important; }
+
+.bare .dashboard-header,
+.bare .query-string,
+.bare .figure-info,
+.bare .advanced-settings-section,
+.bare .comments-footer {
+  display: none;
+}
+
+.bare .col-md-12 {
+  padding: 0;
+}
+
+.query-string {
+  font-size: 18px;
+  margin-bottom: 0;
+}
+
+.bare .distribution {
+  height: 100vh; /* so that it takes window height when embedded */
+  overflow: hidden;
+}
+
+.bare #evolutions {
+  height: 100vh;
+}
+
+.bare {
+  overflow: hidden;
+}
+
+.bare #measure-description,
+.bare #submissions-title,
+.bare #submissions {
+  display: none;
+}


### PR DESCRIPTION
No-frills means no titles, no query strings, no comments and, in the case of evolutions, no submission data.

To use: just set your src to be the url you want plus &bare=true.

It doesn't load very prettily because it doesn't read the options until it has mostly finished rendering.

This is just a quick'n'dirty way to get this capability. To do this more sensibly will require some refactoring of the dashboard code (bug 1220185)