### PR TITLE
3 more tweaks to telemetry-wrapper

### DIFF
--- a/wrapper/README.md
+++ b/wrapper/README.md
@@ -31,8 +31,8 @@ Where `parentEl` is:
 <html>
 <head>
 <title>Simple Example</title>
-<link href="https://telemetry.mozilla.org/new-pipeline/style/metricgraphics.css"/>
-<link href="https://telemetry.mozilla.org/wrapper/telemetry-wrapper.css"/>
+<link rel="stylesheet" href="https://telemetry.mozilla.org/new-pipeline/style/metricsgraphics.css"/>
+<link rel="stylesheet" href="https://telemetry.mozilla.org/wrapper/telemetry-wrapper.css"/>
 </head>
 <body>
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>

--- a/wrapper/README.md
+++ b/wrapper/README.md
@@ -19,6 +19,7 @@ Where `params` is:
 * `trim` - A boolean dictating whether or not you want your histograms to have data under 0.0001% ignored from both ends of your data (default: `true`)
 * `compare` - A string filter name over which we will enumerate all values and plot on the same graph so you can compare the histograms (default: `undefined`)
 * `sensibleCompare` - A boolean dictating whether or not you want to reduce the compared values to just the ones that you are likely to care about (default: `true`)
+* `keyLimit` - a positive integer limiting the number of a keyed measure's measures to be plotted, ordered by number of submissions (default: `4`)
 * `evoVersions` - A number telling us how many versions back to look. If > 0, we will ignore trim, compare, and sensibleCompare and show an evolution instead of a histogram (default: `0`)
 
 Where `parentEl` is:

--- a/wrapper/telemetry-wrapper.js
+++ b/wrapper/telemetry-wrapper.js
@@ -24,19 +24,6 @@ window.TelemetryWrapper.go = function (params, element) {
   Telemetry.init(function () {
     setDefaultParams(params);
 
-    var graphContainerEl = document.createElement('div');
-    graphContainerEl.className = 'graph-container';
-    var graphTitleEl = document.createElement('h2');
-    graphTitleEl.className = 'graph-title';
-    graphContainerEl.appendChild(graphTitleEl);
-    var graphEl = document.createElement('div');
-    graphEl.className = 'graph';
-    var graphLegendEl = document.createElement('div');
-    graphLegendEl.className = 'graph-legend';
-    graphEl.appendChild(graphLegendEl);
-    graphContainerEl.appendChild(graphEl);
-    element.appendChild(graphContainerEl);
-
     var evolutionsPromise;
     if (params.evoVersions > 0) {
       // if we're composing an evolution over many versions, we need to mux over the versions
@@ -167,6 +154,20 @@ window.TelemetryWrapper.go = function (params, element) {
             .map(evo => evo.sanitized())
             .filter(evo => !!evo);
         }
+
+        // Construct the graph elements and add them to `element`
+        var graphContainerEl = document.createElement('div');
+        graphContainerEl.className = 'graph-container';
+        var graphTitleEl = document.createElement('h2');
+        graphTitleEl.className = 'graph-title';
+        graphContainerEl.appendChild(graphTitleEl);
+        var graphEl = document.createElement('div');
+        graphEl.className = 'graph';
+        var graphLegendEl = document.createElement('div');
+        graphLegendEl.className = 'graph-legend';
+        graphEl.appendChild(graphLegendEl);
+        graphContainerEl.appendChild(graphEl);
+        element.appendChild(graphContainerEl);
 
         // Describe the graph, briefly
         var graphTitle = evolutions[0].measure;


### PR DESCRIPTION
First, an augmentation to limit the number of keyed histograms displayed to the `keyLimit` with the most submission counts.

Then a fix to the README to make the example actually look pretty. For some reason I thought we could skip rel="stylesheet" in HTML5, so I let brevity kill correctness.

Then a fix to a regression where only the last key of a keyed histogram would show.