### PR TITLE
dash+wrapper: Add a "grouped bar" chart for comparing multiple boolean/flag histograms

### DIFF
--- a/wrapper/telemetry-wrapper.css
+++ b/wrapper/telemetry-wrapper.css
@@ -68,6 +68,16 @@ svg {
   transform: translateY(2em);
 }
 
+/* for the rotates to look nice, should align text-anchor to start */
+.truths-chart .mg-x-axis text:not(.label) {
+  text-anchor: start;
+}
+
+/* There is no legend in truths-chart, so don't move it so far down */
+.truths-chart .mg-active-datapoint {
+  transform: translateY(1em);
+}
+
 /* MG overrides for a color-blind-friendly palette */
 /* Palette taken from http://mkweb.bcgsc.ca/biovis2012/
  * rgb(0, 0, 0)       rgb(73, 0, 146)     rgb(146, 0, 0)


### PR DESCRIPTION
Looks like this: http://people.mozilla.org/~chutten/media/barGroup.PNG

Live version here: http://bit.ly/1QRXUya (the dashgen doesn't work live on that site because the generated dashes all point back to t.m.o)

Covers #130 