### PR TITLE
wrapper: warn if sanitize removes all data for a particular key.

### DIFF
--- a/wrapper/telemetry-wrapper.js
+++ b/wrapper/telemetry-wrapper.js
@@ -174,6 +174,15 @@ window.TelemetryWrapper.go = function (params, element) {
               return !!evo;
             });
         }
+        if (!evolutions.length) {
+          if (key == '') {
+            // unkeyed histogram with no evolutions. Show a user-visible error
+            showError('All data sanitized away', params, graphContainerEl);
+            return;
+          }
+          console.warn('Whoops? All evolutions sanitized away for key:', key);
+          return;
+        }
 
         // Multiple keys need multiple DOM nodes, in order, in the same place.
         if (oldGraphContainerEl) {


### PR DESCRIPTION
Error out visibly only if the data sanitized away was the only data
for an unkeyed histogram.

Issue #208