### PR TITLE
wrapper: Linkify plot titles to ref a dashboard configured the same way.

### DIFF
--- a/wrapper/telemetry-wrapper.css
+++ b/wrapper/telemetry-wrapper.css
@@ -9,6 +9,10 @@
   flex-direction: column;
 }
 
+.graph-title-link {
+  color: inherit;
+}
+
 .graph-title {
   font-family: sans-serif;
   font-size: 18px;


### PR DESCRIPTION
This way you can get to a dist.html or evo.html from a plot if you want to
change the params a bit.

The dashes' application filter does not support 'no filter', so translate that
to 'Firefox!Fennec' to get most of the way there.

Issue #199 