### PR TITLE
dash: The mouseover text isn't using % signs for boolean plots.

### DIFF
--- a/new-pipeline/src/evo.js
+++ b/new-pipeline/src/evo.js
@@ -353,7 +353,7 @@ $(function () {
           }
           displayEvolutions(lines, submissionLines, $(
               "input[name=build-time-toggle]:checked")
-            .val() !== "0", gCurrentKind === "enumerated");
+            .val() !== "0", gCurrentKind === "enumerated" || gCurrentKind === "boolean");
           saveStateToUrlAndCookie();
         });
 


### PR DESCRIPTION
It thought that only enumerated plots needed % signs.

Issue #212