### PR TITLE
Fix empty histograms set

### DIFF
--- a/new-pipeline/src/dist.js
+++ b/new-pipeline/src/dist.js
@@ -992,10 +992,10 @@ function displaySingleHistogramSet(axes, useTable, histograms, title,
   $(axes)
     .empty(); // Remove tables if they are present
 
-  $('#dist-caption').text(histograms[0].description);
 
   // No histograms available
   if (histograms.length === 0) {
+    $('#dist-caption').text(""); // Clear the histogram caption
     MG.data_graphic({
       chart_type: "missing-data",
       width: $(axes)
@@ -1021,6 +1021,9 @@ function displaySingleHistogramSet(axes, useTable, histograms, title,
     });
     return;
   }
+
+  // Set the histogram caption to the histogram description
+  $('#dist-caption').text(histograms[0].description);
 
   // All histograms must have the same buckets and be of the same kind
   var starts = histograms[0].map(function (count, start, end, i) {


### PR DESCRIPTION
When the set of histograms is empty, `histograms[0]` is not defined. Example of `TypeError`: https://telemetry.mozilla.org/new-pipeline/dist.html#!cumulative=0&end_date=2016-01-19&keys=__none__!__none__!__none__&max_channel_version=aurora%252F45&measure=LOOP_SHARING_ROOM_URL&min_channel_version=null&product=Firefox&sanitize=1&sort_keys=submissions&start_date=2015-12-17&table=0&trim=1&use_submission_date=0