### PR TITLE
Select 5th percentile, median, and 95th percentile by default

### DIFF
--- a/new-pipeline/src/evo.js
+++ b/new-pipeline/src/evo.js
@@ -436,8 +436,8 @@ function updateAggregates(callback) {
             var newAggregates = gDefaultAggregates.map(function (entry) {
               return [entry[0], entry[1]];
             });
-            multiselectSetOptions($("#aggregates"), newAggregates, [
-              "median"]);
+
+            multiselectSetOptions($("#aggregates"), newAggregates, ["median", "5th-percentile", "95th-percentile"]);
           }
 
           // Load aggregates from state on first load


### PR DESCRIPTION
As requested by :smaug in #perf - showing upper and lower percentiles make it easier to see certain regressions.