### PR TITLE
Fix mixed content warning.

### DIFF
--- a/update-orphaning/index.html
+++ b/update-orphaning/index.html
@@ -2,8 +2,8 @@
 <html>
 <head>
 <meta charset="utf-8">
-<script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.6.2/jquery.min.js"> </script>
-<script type="text/javascript" src="http://d3js.org/d3.v3.min.js" charset="utf-8"></script>
+<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.2/jquery.min.js"> </script>
+<script type="text/javascript" src="https://d3js.org/d3.v3.min.js" charset="utf-8"></script>
 <script type="text/javascript" src="https://telemetry.mozilla.org/new-pipeline/lib/d3pie.min.js"></script>
 <style>
 


### PR DESCRIPTION
@chutten - Sorry, I didn't notice this mixed content warning on http://sapohl.github.io/telemetry-dashboard/update-orphaning/ because I didn't check the https:// variant of the URL, but this warning breaks https://telemetry.mozilla.org/update-orphaning/ since it's only served via https://.