### PR TITLE
Use https for shortened links.

### DIFF
--- a/new-pipeline/src/dashboards.js
+++ b/new-pipeline/src/dashboards.js
@@ -159,6 +159,9 @@ $(document)
           success: function (response) {
             var longUrl = Object.keys(response.results)[0];
             var shortUrl = response.results[longUrl].shortUrl;
+            if (shortUrl.indexOf(":") === 4) {
+              shortUrl = "https" + shortUrl.substring(4);
+            }
             $this.parents(".permalink-control")
               .find("input")
               .show()


### PR DESCRIPTION
bit.ly seems to return only http links, so let's detect and fix that.

Issue #229

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-dashboard/230)
<!-- Reviewable:end -->
