### PR TITLE
Make update orphaning dashboard aware of the new Airflow-specific URL

### DIFF
--- a/update-orphaning/index.html
+++ b/update-orphaning/index.html
@@ -103,7 +103,7 @@ This dashboard is managed by <a href="mailto:spohl@mozilla.com">:spohl</a>.<br/>
 The Spark script for the weekly reports is scheduled to run every Wednesday and can be found <a href="https://github.com/mozilla-services/data-pipeline/tree/master/reports/update-orphaning/Update orphaning analysis using longitudinal dataset.ipynb">here</a>.
 
 <script>
-  var dataUrl = "https://analysis-output.telemetry.mozilla.org/update-orphaning-weekly-analysis/data/";
+  var dataUrl = "https://s3-us-west-2.amazonaws.com/telemetry-public-analysis-2/data/spohl@mozilla.com/Update+Orphaning+View/";
   var branch = "";
   var wedAsWeekday = 3;
   var today = new Date();
@@ -116,6 +116,11 @@ The Spark script for the weekly reports is scheduled to run every Wednesday and 
   }
   var lastWedDate = new Date();
   lastWedDate.setDate(today.getDate() - daysToLastWed);
+
+  // The Airflow Spark job scheduler currently works with a one week delay, so
+  // we have to drop the most recent date as an option in the dropdown menu.
+  lastWedDate.setDate(lastWedDate.getDate() - 7);
+
   var year = lastWedDate.getFullYear();
   var month = lastWedDate.getMonth() + 1;
   if (month < 10) {


### PR DESCRIPTION
needs-review: @chutten 

We now schedule the weekly Spark job for the update orphaning dashboard
via Airflow. Airflow uses a new URL for the output files. Airflow also
operates on a one-week delay, so we have to drop the most recent date
as an option from the dropdown menu in the dashboard.

Note: older data files will be copied manually to the new location.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-dashboard/238)
<!-- Reviewable:end -->
