### PR TITLE
Accommodate new weekday when update orphaning Spark job is run

### DIFF
--- a/update-orphaning/index.html
+++ b/update-orphaning/index.html
@@ -105,14 +105,14 @@ The Spark script for the weekly reports is scheduled to run every Wednesday and 
 <script>
   var dataUrl = "https://s3-us-west-2.amazonaws.com/telemetry-public-analysis-2/data/spohl@mozilla.com/Update+Orphaning+View/";
   var branch = "";
-  var wedAsWeekday = 3;
   var today = new Date();
   var todaysWeekday = today.getDay();
   var daysToLastWed = 0;
-  if (todaysWeekday >= wedAsWeekday) {
-    daysToLastWed = todaysWeekday - wedAsWeekday;
+
+  if (todaysWeekday == 0) {
+    daysToLastWed = 11;
   } else {
-    daysToLastWed = 7 - (wedAsWeekday - todaysWeekday);
+    daysToLastWed = 4 + todaysWeekday;
   }
   var lastWedDate = new Date();
   lastWedDate.setDate(today.getDate() - daysToLastWed);


### PR DESCRIPTION
needs-review: @chutten 

The update orphaning Spark job is now scheduled to run right after the
longitudinal dataset creation job on Sunday, instead of Wednesday. The
dates need to be adjusted as follows:

Monday: -5
Tuesday: -6
Wednesday: -7
Thursday: -8
Friday: -9
Saturday: -10
Sunday: -11

Note that this is in addition to the 7-day adjustment a few lines below
because of the fact that Airflow schedules these jobs with a one week
delay.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-dashboard/239)
<!-- Reviewable:end -->
