### PR TITLE
#e10s-graph no longer exists, but #e10s-graph1 does

### DIFF
--- a/crashes/office-dashboard.js
+++ b/crashes/office-dashboard.js
@@ -39,7 +39,7 @@ document.addEventListener("DOMContentLoaded", function() {
     function(data) {
       setup_e10s_graph(data);
     },
-    graph_error.bind(undefined, "#e10s-graph")
+    graph_error.bind(undefined, "#e10s-graph1")
   );
 });
 


### PR DESCRIPTION
Small fix to show the "no data" graph image on data failure.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-dashboard/247)
<!-- Reviewable:end -->
