### PR TITLE
Bug 1312420 - Don't try to use + on things that could be either strings or numbers

### DIFF
--- a/update-orphaning/index.html
+++ b/update-orphaning/index.html
@@ -132,7 +132,7 @@ The Spark script for the weekly reports is scheduled to run every Wednesday and 
   }
   var friAfterLastWedDate = new Date();
   friAfterLastWedDate.setDate(lastWedDate.getDate() + 2);
-  var lastWedDataFile = year + month + date + ".json";
+  var lastWedDataFile = [year, month, date, ".json"].join("");
   var startDate = new Date();
   startDate.setDate(2);
   startDate.setMonth(2);


### PR DESCRIPTION
This dashboard builds a file name to fetch by using + to concatenate a year, month, and day. If the month is before October, it has to get a 0 prepended, forcing its conversion to a string. But in October or later, when that doesn't happen, the components are all still numbers and + adds them up as numbers instead of concatenating them as strings.
So, here we switch to a method of building the file name string that doesn't care what the types of the components are.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-dashboard/253)
<!-- Reviewable:end -->
