### PR TITLE
Allow filters to have multiple values

### DIFF
--- a/v2/telemetry.js
+++ b/v2/telemetry.js
@@ -505,8 +505,15 @@
     Object.keys(filters)
       .sort()
       .forEach(function (filterName) { // we need to sort the keys in order to make sure the same filters result in the same URL each time, for caching
-        filterString += "&" + encodeURIComponent(filterName) + "=" +
-          encodeURIComponent(filters[filterName]);
+        var filter = filters[filterName];
+        if (!Array.isArray(filter)) {
+          filter = [filter];
+        }
+
+        for (var i = 0; i < filter.length; ++i) {
+          filterString += "&" + encodeURIComponent(filterName) + "=" +
+            encodeURIComponent(filter[i]);
+        }
       });
     var url = Telemetry.BASE_URL + "aggregates_by/" + (useSubmissionDate ?
         "submission_date" : "build_id") +


### PR DESCRIPTION
This allows me to do this:

```JavaScript
Telemetry.getEvolution(channel, version, TAB_SPINNER, {os: ["Linux", "Darwin"], e10sEnabled: "true"}, false /* useSubmissionDate */, evolutionMap => {
  //...
});
```
Whereas before I could only specify a single OS at a time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-dashboard/264)
<!-- Reviewable:end -->
