### PR TITLE
Bug 1316031 - Enable categorical histogram viewing

### DIFF
--- a/new-pipeline/src/dashboards.js
+++ b/new-pipeline/src/dashboards.js
@@ -717,6 +717,8 @@ function getHumanReadableBucketOptions(kind, buckets) {
         " percentage"
       ];
     });
+  } else if (kind == "categorical") {
+    return buckets.map( (b, i) => [i.toString(), b] )
   }
 
   return buckets.map(function (start) {

--- a/new-pipeline/src/evo.js
+++ b/new-pipeline/src/evo.js
@@ -353,9 +353,9 @@ $(function () {
             lines = gCurrentLinesMap[key];
             submissionLines = gCurrentSubmissionLinesMap[key];
           }
-          displayEvolutions(lines, submissionLines, $(
-              "input[name=build-time-toggle]:checked")
-            .val() !== "0", gCurrentKind === "enumerated" || gCurrentKind === "boolean");
+          displayEvolutions(lines, submissionLines,
+            $("input[name=build-time-toggle]:checked").val() !== "0",
+            gCurrentKind === "enumerated" || gCurrentKind === "boolean" || gCurrentKind == "categorical");
           saveStateToUrlAndCookie();
         });
 
@@ -422,7 +422,11 @@ function updateAggregates(callback) {
               realBuckets);
             multiselectSetOptions($("#aggregates"), newAggregates, [
               newAggregates[0][0]]);
-          } else if (realKind === "boolean" || realKind === "flag") {
+          } else if(realKind == "categorical") {
+            var newAggregates = realBuckets.map((r, i) => {return [i.toString(), r]})
+            multiselectSetOptions($("#aggregates"), newAggregates, [
+              newAggregates[0][0]]);
+          }  else if (realKind === "boolean" || realKind === "flag") {
             var newAggregates = getHumanReadableBucketOptions(realKind,
               realBuckets);
             multiselectSetOptions($("#aggregates"), newAggregates, [
@@ -620,9 +624,9 @@ function getHistogramEvolutionLines(channel, version, measure, aggregates,
             gDefaultAggregates.forEach(function (entry) {
               aggregateSelector[entry[0]] = entry[2];
             });
+            var options = getHumanReadableBucketOptions(evolution.kind, evolution.buckets)
             evolution.buckets.forEach(function (start, bucketIndex) {
-              var option = getHumanReadableBucketOptions(evolution.kind, [
-                start])[0][0];
+              var option = options[bucketIndex][0];
               aggregateSelector[option] = function (evolution) {
                 return evolution.map(function (histogram) {
                   return 100 * histogram.values[bucketIndex] /

--- a/v2/telemetry.js
+++ b/v2/telemetry.js
@@ -23,10 +23,10 @@
   Telemetry.Histogram = (function () {
     function Histogram(buckets, values, kind, submissions, sum,
       description, measure) {
-      assert(typeof buckets[0] === "number", "`buckets` must be an array");
+      assert(["number", "string"].indexOf(typeof buckets[0]) > -1, "`buckets` must be an array, is " + (typeof buckets[0]));
       assert(typeof values[0] === "number", "`values` must be an array");
       assert(["flag", "boolean", "count", "enumerated", "linear",
-          "exponential"].indexOf(kind) >= 0,
+          "exponential", "categorical"].indexOf(kind) >= 0,
         "`kind` must be a valid histogram kind");
       assert(typeof submissions === "number",
         "`submissions` must be a number");
@@ -130,7 +130,7 @@
 
   Telemetry.Evolution = (function () {
     function Evolution(buckets, data, kind, description, measure) {
-      assert(typeof buckets[0] === "number", "`buckets` must be an array");
+      assert(["number", "string"].indexOf(typeof buckets[0]) > -1, "`buckets` must be an array, is " + (typeof buckets[0]));
       assert(typeof data[0].histogram[0] === "number",
         "`data` must be an array");
       assert(typeof kind === "string", "`kind` must be a string");


### PR DESCRIPTION
Buckets are string labels. Otherwise, categorical histograms
behave like enumerated ones.

@chutten r?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-dashboard/278)
<!-- Reviewable:end -->
