### PR TITLE
Issue #281 - Use the most-recent version, not the most-used version for the crash dash

### DIFF
--- a/new-pipeline/dist.html
+++ b/new-pipeline/dist.html
@@ -44,7 +44,7 @@
                     with
                     <select id="filter-e10s" class="multiselect" title="e10s setting" data-all-selected="any e10s setting" multiple></select>
                     as
-                    <select id="filter-process-type" class="multiselect" title="Process type" data-all-selected="any process type" multiple></select>
+                    <select id="filter-process-type" class="multiselect" title="Process type" data-all-selected="any process type"></select>
                     and compare by
                     <select id="compare" class="multiselect" title="Filter name to compare options for">
                         <option value="">none</option>

--- a/new-pipeline/evo.html
+++ b/new-pipeline/evo.html
@@ -54,7 +54,7 @@
                     with
                     <select id="filter-e10s" class="multiselect" title="e10s setting" data-all-selected="any e10s setting" multiple></select>
                     as
-                    <select id="filter-process-type" class="multiselect" title="Process type" data-all-selected="any process type" multiple></select>
+                    <select id="filter-process-type" class="multiselect" title="Process type" data-all-selected="any process type"></select>
                 </h2>
                 <h3 id="measure-description" style="font-size: 14px; margin: 0 3px"></h3>
                 <h2 style="font-size: 18px; margin-bottom: 0">Showing graphs for <select id="selected-key" class="multiselect" title="Selected key"></select></h3>

--- a/new-pipeline/src/dashboards.js
+++ b/new-pipeline/src/dashboards.js
@@ -33,7 +33,7 @@ $(document)
         };
 
         // Horrible hacks to make some very specific functionality work
-        if (["aggregates", "filter-os"].indexOf($this.attr("id")) >= 0) {
+        if (["aggregates", "filter-os"].includes($this.attr("id"))) {
           // Add the Select All option to some of the selectors
           options.includeSelectAllOption = true;
         }
@@ -333,6 +333,13 @@ function getFilterSetsMapping(filters, comparisonName) {
       .length) { // Some options are not selected, so we need to explicitly filter
       if (filterName === "os") {
         selected = compressOSs();
+      } else if (filterName === "child") {
+        // process type is now single-select.
+        if (selector.val() === "*") {
+          // Any process
+          continue;
+        }
+        selected = [selected];
       }
       if (filterName !== comparisonName) { // avoid filtering by the comparison name
         filterMapping[filterName] = selected;
@@ -387,6 +394,15 @@ function getFilterSetsMapping(filters, comparisonName) {
       break;
     case "osVersion":
       comparisonValues = filters["os"].val() || [];
+      break;
+    case "child":
+      if (filters["child"].val() === "*") {
+        comparisonValues = Array.from(filters["child"][0].options)
+          .filter(opt => opt.value !== "*")
+          .map(opt => opt.value);
+      } else {
+        comparisonValues = filters["child"] ? [filters["child"].val()] : [];
+      }
       break;
     default:
       comparisonValues = filters[comparisonName].val() || [];
@@ -596,8 +612,8 @@ function getHumanReadableOptions(filterName, options) {
   } else if (filterName === "child") {
     return options.map(function (option) {
       return [option, processTypeNames.hasOwnProperty(option) ?
-        processTypeNames[option] : option];
-    });
+        processTypeNames[option] : option + " process"];
+    }).concat([["*", "any process"]]);
   } else if (filterName === "measure") {
     // Add a hidden version of the option with spaces instead of underscores, to be able to search with spaces
     return options.sort()

--- a/new-pipeline/src/dist.js
+++ b/new-pipeline/src/dist.js
@@ -117,7 +117,7 @@ $(function () {
           .multiselect("select", gInitialPageState.processType);
       } else {
         $("#filter-process-type")
-          .multiselect("selectAll", false)
+          .multiselect("select", "*")
           .multiselect("updateButtonText");
       }
 

--- a/new-pipeline/src/dist.js
+++ b/new-pipeline/src/dist.js
@@ -1851,18 +1851,4 @@ function saveStateToUrlAndCookie() {
       .find("span")
       .text("");
   }
-
-  // Reload Disqus comments for the new page state
-  var identifier = "dist@" + gInitialPageState.measure;
-  if (identifier !== gPreviousDisqusIdentifier) {
-    gPreviousDisqusIdentifier = identifier;
-    DISQUS.reset({
-      reload: true,
-      config: function () {
-        this.page.identifier = identifier;
-        this.page.url = window.location.href;
-        console.log("reloading comments for page ID ", this.page.identifier)
-      }
-    });
-  }
 }

--- a/new-pipeline/src/evo.js
+++ b/new-pipeline/src/evo.js
@@ -136,7 +136,7 @@ $(function () {
           .multiselect("select", gInitialPageState.processType);
       } else {
         $("#filter-process-type")
-          .multiselect("selectAll", false)
+          .multiselect("select", "*")
           .multiselect("updateButtonText");
       }
 

--- a/new-pipeline/src/evo.js
+++ b/new-pipeline/src/evo.js
@@ -1231,18 +1231,4 @@ function saveStateToUrlAndCookie() {
       .find("span")
       .text("");
   }
-
-  // Reload Disqus comments for the new page state
-  var identifier = "evo@" + gInitialPageState.measure;
-  if (identifier !== gPreviousDisqusIdentifier) {
-    gPreviousDisqusIdentifier = identifier;
-    DISQUS.reset({
-      reload: true,
-      config: function () {
-        this.page.identifier = identifier;
-        this.page.url = window.location.href;
-        console.log("reloading comments for page ID ", this.page.identifier)
-      }
-    });
-  }
 }


### PR DESCRIPTION
The crash dash currently displays the most-used version per channel in an
effort to maximize the crash rate denominator "kuh".

This isn't terribly helpful as, once a new release lands, we cease to really
care about the stability of the old one.

So track the release schedule using https://product-details.mozilla.org and
only use data from the most recent release.

Issue #281

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-dashboard/282)
<!-- Reviewable:end -->
