### PR TITLE
crashdash - make the plots taller to show better on widescreens

### DIFF
--- a/crashes/style.css
+++ b/crashes/style.css
@@ -35,7 +35,7 @@ thead {
 }
 
 #crash-plot-container {
-  height: 25vh;
+  height: 50vh;
   width: 90vw;
   margin: 2vmin 0;
 }
@@ -81,7 +81,7 @@ thead {
 }
 
 #kuh-plot-container {
-  height: 25vh;
+  height: 40vh;
   width: 90vw;
   margin: 2vmin 0;
 }


### PR DESCRIPTION
The crashdash plots look fine on my ancient 5:4 monitor, but are rather squished on widescreens. Give 'em a growth spurt.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-dashboard/285)
<!-- Reviewable:end -->
