### PR TITLE
bug 1349536 - Add "Other" channel to crashdash

### DIFF
--- a/crashes/index.html
+++ b/crashes/index.html
@@ -28,6 +28,7 @@
       <td>Aurora</td>
       <td>Beta</td>
       <td>Release</td>
+      <td>Other</td>
     </tr>
     <tr>
       <td>Version</td>
@@ -56,7 +57,7 @@
 -->
 <script>
 
-const CHANNELS = ["nightly", "aurora", "beta", "release"];
+const CHANNELS = ["nightly", "aurora", "beta", "release", "Other"];
 const PERCENT_NOTICE_THRESHOLD = 0.5;
 
 var gData = undefined;
@@ -111,7 +112,7 @@ xhr.addEventListener("load", function() {
       gMap[row.activity_date][row.channel] = row;
       return;
     }
-    if (gLatestVersions) {
+    if (gLatestVersions && row.channel in gLatestVersions[row.activity_date]) {
       if (row.build_version == gLatestVersions[row.activity_date][row.channel]) {
         gMap[row.activity_date][row.channel] = row;
       }

--- a/crashes/thresholds.js
+++ b/crashes/thresholds.js
@@ -43,4 +43,11 @@ const THRESHOLDS = {
     [CRASH_NAMES.MCS]: {lo: 3.03, hi: 4.02},
     [CRASH_NAMES.P]: {lo: 5.99, hi: 9.74},
   },
+  "Other": {
+    [CRASH_NAMES.M]: {lo: 2.17, hi: 4.07},
+    [CRASH_NAMES.MC]: {lo: 3.95, hi: 6.89},
+    [CRASH_NAMES.CS]: {lo: 0.81, hi: 0.88},
+    [CRASH_NAMES.MCS]: {lo: 3.03, hi: 4.02},
+    [CRASH_NAMES.P]: {lo: 5.99, hi: 9.74},
+  },
 };


### PR DESCRIPTION
With users of old versions of Windows having been migrated to ESR in 52, it
suddenly becomes interesting to look at ESR crash rates and adoption.

Sadly ESR doesn't fit into the nice "latest versions" mechanism, so for now it
is reporting the most-used version. This works well for the latest ESR because
of the aforementioned influx of users, but may need to be tweaked in time for
the next one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-dashboard/301)
<!-- Reviewable:end -->
