### PR TITLE
Bug 1241136   -copy the shortened links

### DIFF
--- a/new-pipeline/src/dashboards.js
+++ b/new-pipeline/src/dashboards.js
@@ -149,16 +149,15 @@ $(document)
       .click(function () {
         var $this = $(this);
         $.ajax({
-          url: "https://api-ssl.bitly.com/shorten",
-          dataType: "jsonp",
+          url: "https://api-ssl.bitly.com/v3/shorten",
+          dataType: "json",
           data: {
             longUrl: window.location.href,
             access_token: "48ecf90304d70f30729abe82dfea1dd8a11c4584",
             format: "json"
           },
           success: function (response) {
-            var longUrl = Object.keys(response.results)[0];
-            var shortUrl = response.results[longUrl].shortUrl;
+            var shortUrl = response.data.url;
             if (shortUrl.indexOf(":") === 4) {
               shortUrl = "https" + shortUrl.substring(4);
             }
@@ -167,8 +166,10 @@ $(document)
               .show()
               .val(shortUrl)
               .focus();
-          }
+          },
+          async:false
         });
+        document.execCommand('copy');
       });
   });
 


### PR DESCRIPTION
This is an enhancement to Telemetry Dashboard shortened links.

Previously the shortened links were revealed on clicking but couldn't be copied without hitting ^C.Now we can copy the shortened link in telemetry dashboards without a need to remember to hit ^C.

**APPROACH**

Initially it seemed adding  `document.execCommand('copy')` in the response handler will do the trick.
This also required the AJAX to be synchronous, so that `document.execCommand('copy')` gets called only after the AJAX response (after getting the shortened link in input ) . 
However  with  `dataType: "jsonp"`  XHR can't be made synchronous after all it's not AJAX .
So[ v3 bit.ly API](http://dev.bitly.com/links.html#v3_shorten) is used to here make the process synchronous, as the `dataType` here is `json` .

**SOME BACKGROUND**
- About [document.execCommand()](https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand)
- Browser support for [document.execCommand()](http://caniuse.com/#search=document.execCommand())

**LIVE PREVIEW**

This can be reviewed here https://hemant1612.github.io/.


Special thanks to @chutten for guiding me :).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-dashboard/304)
<!-- Reviewable:end -->
