### PR TITLE
bug 1355541 - Use the new ESR normalized-channel instead of Other.

### DIFF
--- a/crashes/index.html
+++ b/crashes/index.html
@@ -28,7 +28,7 @@
       <td>Aurora</td>
       <td>Beta</td>
       <td>Release</td>
-      <td>Other</td>
+      <td>ESR</td>
     </tr>
     <tr>
       <td>Version</td>
@@ -57,7 +57,7 @@
 -->
 <script>
 
-const CHANNELS = ["nightly", "aurora", "beta", "release", "Other"];
+const CHANNELS = ["nightly", "aurora", "beta", "release", "esr"];
 const PERCENT_NOTICE_THRESHOLD = 0.5;
 
 var gData = undefined;
@@ -106,6 +106,10 @@ xhr.addEventListener("load", function() {
   gData.rows.forEach(row => {
     if (!(row.activity_date in gMap)) {
       gMap[row.activity_date] = {};
+    }
+    // Before 2017-04-19 ESR was in 'Other'
+    if (row.channel === 'Other' && row.activity_date < '2017-04-19') {
+      row.channel = 'esr';
     }
     // Ensure every date for every channel has a row.
     if (!(row.channel in gMap[row.activity_date])) {

--- a/crashes/thresholds.js
+++ b/crashes/thresholds.js
@@ -43,7 +43,7 @@ const THRESHOLDS = {
     [CRASH_NAMES.MCS]: {lo: 3.03, hi: 4.02},
     [CRASH_NAMES.P]: {lo: 5.99, hi: 9.74},
   },
-  "Other": {
+  "esr": {
     [CRASH_NAMES.M]: {lo: 2.17, hi: 4.07},
     [CRASH_NAMES.MC]: {lo: 3.95, hi: 6.89},
     [CRASH_NAMES.CS]: {lo: 0.81, hi: 0.88},


### PR DESCRIPTION
bug 1352091 split 'esr' out as separate from 'Other' starting on 2017-04-19.
So let's use 'Other' before that date and 'esr' from then on.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-dashboard/305)
<!-- Reviewable:end -->
