### PR TITLE
Link Background Hang Reporting to new dashboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,7 +103,7 @@
                         Stability Dashboard <div class="dashboard-description">See how crash rates evolve over time</div>
                     </a>
                     <a class="list-group-item" href="https://squarewave.github.io">
-                        Background Hang Reporting
+                        Background Hang Reporting <div class="dashboard-description">View browser hang information collected from Nightly users</div>
                     </a>
                     <span class="list-group-item disabled">
                         Addon Startup Correlations

--- a/index.html
+++ b/index.html
@@ -102,16 +102,15 @@
                     <a class="list-group-item" href="crashes/">
                         Stability Dashboard <div class="dashboard-description">See how crash rates evolve over time</div>
                     </a>
+                    <a class="list-group-item" href="https://squarewave.github.io">
+                        Background Hang Reporting
+                    </a>
                     <span class="list-group-item disabled">
                         Addon Startup Correlations
                         <div class="dashboard-description">Please <a href="https://github.com/mozilla/telemetry-dashboard/issues">Report a Bug</a> if you require this data.</div>
                     </span>
                     <span class="list-group-item disabled">
                         Addon Shutdown Correlations
-                        <div class="dashboard-description">Please <a href="https://github.com/mozilla/telemetry-dashboard/issues">Report a Bug</a> if you require this data.</div>
-                    </span>
-                    <span class="list-group-item disabled">
-                        Background Hang Reporting
                         <div class="dashboard-description">Please <a href="https://github.com/mozilla/telemetry-dashboard/issues">Report a Bug</a> if you require this data.</div>
                     </span>
                     <span class="list-group-item disabled">


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1344003 for
more context. In short, I created a profiler-like UI for hang
data available on my GitHub Pages page. This change links the
Background Hang Reporting link on the main view to this page.