### PR TITLE
Fix the recommendation page to use the new mapping format

### DIFF
--- a/addon-recommender/index.html
+++ b/addon-recommender/index.html
@@ -53,7 +53,9 @@
       <div class="row">
         <div class="col-md-12">
           <p class="lead text-justify">
-            The model is trained with the IDs of the add-ons reported by the users. Add-ons which are not publicly reported by the <a href="https://addons.mozilla.org">addons.mozilla.org</a> web API are excluded from the model.
+            The model is trained with the IDs of the add-ons reported by the users, both legacy and
+            using webextensions. Add-ons which are not publicly reported by the <a href="https://addons.mozilla.org">addons.mozilla.org</a> web API are excluded from the model. The page
+            will <b>only suggest non-legacy addons</b>.
           </p>
           <p class="lead text-justify">
             <strong>Know issues and future work</strong>

--- a/addon-recommender/js/main.js
+++ b/addon-recommender/js/main.js
@@ -18,7 +18,7 @@ function setupAutocomplete() {
   var suggestions = []
 
   for (var addonId in addonMapping) {
-    suggestions.push({id: addonId, text: addonMapping[addonId]});
+    suggestions.push({id: addonId, text: addonMapping[addonId].name});
   }
 
   let sortFunc = function(data) {
@@ -83,9 +83,10 @@ function suggestAddons(addonIds) {
   rawItemsMatrix.forEach(addon => {
     // We don't really need to show the items we requested. They will always
     // end up with the greatest score.
-    if (!addonIdsAsNumbers.includes(addon.id)) {
+    if (!addonIdsAsNumbers.includes(addon.id) &&
+        addonMapping[addon.id].isWebextension) {
       const d = math.dot(tUserFactors, addon.features);
-      distances[addonMapping[addon.id]] = d;
+      distances[addonMapping[addon.id].name] = d;
     }
   });
 


### PR DESCRIPTION
The format changed from {"hashed_id": "name"} to
{"hashed_id": {"name": "Some Name", "id": "addon guid", ...}.
This commit also makes the recommender only recommend
non-legacy addons.