### PR TITLE
Bug 1338941 - use jQuery instead of manually building option HTML

### DIFF
--- a/new-pipeline/src/dashboards.js
+++ b/new-pipeline/src/dashboards.js
@@ -844,15 +844,11 @@ function multiselectSetOptions(element, options, defaultSelected) {
     });
     element.empty()
       .append(groups.map(function (group) {
-          var optionsString = groupOptions[group].map(function (triple) {
-              return '<option value="' + triple[0] + '">' + triple[1] +
-                '</option>';
-            })
-            .join();
-          return '<optgroup label="' + group + '">' + optionsString +
-            '</optgroup>'
-        })
-        .join())
+        return $('<optgroup>', {label: group})
+          .append(groupOptions[group].map(function (triple) {
+            return $("<option>", {value: triple[0]}).text(triple[1]);
+          }));
+        }))
       .multiselect("rebuild");
   } else { // Build option elements
     options.forEach(function (option) {
@@ -869,12 +865,10 @@ function multiselectSetOptions(element, options, defaultSelected) {
     element.empty()
       .append(options.map(function (option) {
           if (option === null) {
-            return '<option disabled>&nbsp;</option>';
+            return $('<option>').prop('disabled', true);
           }
-          return '<option value="' + option[0] + '">' + option[1] +
-            '</option>';
-        })
-        .join())
+          return $('<option>', {value: option[0]}).text(option[1]);
+        }))
       .multiselect("rebuild");
   }
 


### PR DESCRIPTION
Bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1288949

Bug repro: [link](https://telemetry.mozilla.org/new-pipeline/dist.html#!cumulative=0&end_date=2016-08-01&keys=All!AV%252C240%253Ch%253C%253D480!V%252C240%253Ch%253C%253D480!AV%252C0%253Ch%253C%253D240&max_channel_version=nightly%252F50&measure=VIDEO_HIDDEN_PLAY_TIME_PERCENTAGE&min_channel_version=null&processType=*&product=Firefox&sanitize=1&sort_keys=submissions&start_date=2016-07-22&table=0&trim=1&use_submission_date=0)
Same page, temporary server with this patch applied: [link](
http://212.71.251.88:8050/new-pipeline/dist.html#!cumulative=0&end_date=2016-08-01&keys=All!AV%252C240%253Ch%253C%253D480!V%252C240%253Ch%253C%253D480!AV%252C0%253Ch%253C%253D240&max_channel_version=nightly%252F50&measure=VIDEO_HIDDEN_PLAY_TIME_PERCENTAGE&min_channel_version=null&processType=*&product=Firefox&sanitize=1&sort_keys=submissions&start_date=2016-07-22&table=0&trim=1&use_submission_date=0)

Things I'm not sure about:
- Should both `dashboards.js` be fixed, or only the `new-pipeline` one?
- I removed `&nbsp;`, as I didn't see how it changed anything, but maybe I missed something.
