### PR TITLE
Bug 1365751 - correctly handle keyed histograms with a single key

### DIFF
--- a/new-pipeline/src/dist.js
+++ b/new-pipeline/src/dist.js
@@ -881,6 +881,13 @@ function displayHistograms(histogramsList, dates, useTable, cumulative, trim) {
     });
   }
 
+  if (histogramsList.length > 0 && histogramsList[0].histograms.length > 0) {
+    // Set the histogram caption to the histogram description
+    $('#dist-caption').text(histogramsList[0].histograms[0].description);
+  } else {
+    $('#dist-caption').text(""); // Clear the histogram caption
+  }
+
   if (histogramsList.length <= 1) { // Only one histograms set
     if (histogramsList.length === 1 && histogramsList[0].histograms.length ===
       1) { // Only show one set of axes
@@ -998,7 +1005,6 @@ function displaySingleHistogramSet(axes, useTable, histograms, title,
 
   // No histograms available
   if (histograms.length === 0) {
-    $('#dist-caption').text(""); // Clear the histogram caption
     MG.data_graphic({
       chart_type: "missing-data",
       width: $(axes)
@@ -1024,9 +1030,6 @@ function displaySingleHistogramSet(axes, useTable, histograms, title,
     });
     return;
   }
-
-  // Set the histogram caption to the histogram description
-  $('#dist-caption').text(histograms[0].description);
 
   // All histograms must have the same buckets and be of the same kind
   var starts = histograms[0].map(function (count, start, end, i) {

--- a/new-pipeline/src/dist.js
+++ b/new-pipeline/src/dist.js
@@ -942,10 +942,13 @@ function displayHistograms(histogramsList, dates, useTable, cumulative, trim) {
     axesContainer.removeClass("col-md-6")
       .addClass("col-md-12")
       .show();
-    axesContainer.find("h3")
-      .hide(); // Hide the graph title as it doesn't need one
-    $("#sort-keys-option")
-      .hide();
+    if (isHistogramsListKeyed(histogramsList)) {
+      axesContainer.find("h3").show();
+      $("#sort-keys-option").show();
+    } else {
+      axesContainer.find("h3").hide(); // Hide the graph title as it doesn't need one
+      $("#sort-keys-option").hide();
+    }
 
     if (histogramsList.length > 0) {
       displaySingleHistogramSet($("#distribution1")
@@ -1735,7 +1738,7 @@ function saveStateToUrlAndCookie() {
     }
     var jsonValue;
     var csvValue;
-    if (gCurrentHistogramsList.length == 1) {
+    if (!isHistogramsListKeyed(gCurrentHistogramsList)) {
       jsonValue = JSON.stringify(histograms[0].map(function (count, start,
         end, i) {
         var entry = {
@@ -1851,4 +1854,8 @@ function saveStateToUrlAndCookie() {
       .find("span")
       .text("");
   }
+}
+
+function isHistogramsListKeyed(histogramsList) {
+  return histogramsList.some(entry => entry.title !== "");
 }


### PR DESCRIPTION
Bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1365751

Bug repro: [link](http://telemetry.mozilla.org/new-pipeline/dist.html#!cumulative=0&end_date=2017-08-25&keys=content%253Aamd64%252F49!__none__!__none__!__none__&max_channel_version=aurora%252F56&measure=SANDBOX_REJECTED_SYSCALLS&min_channel_version=null&os=Linux&processType=*&product=Firefox&sanitize=0&sort_keys=submissions&start_date=2017-08-21&table=0&trim=1&use_submission_date=0)
Same page, temporary server with this patch applied: [link](http://212.71.251.88:8050/new-pipeline/dist.html#!cumulative=0&end_date=2017-08-25&keys=content%253Aamd64%252F49!__none__!__none__!__none__&max_channel_version=aurora%252F56&measure=SANDBOX_REJECTED_SYSCALLS&min_channel_version=null&os=Linux&processType=*&product=Firefox&sanitize=0&sort_keys=submissions&start_date=2017-08-21&table=0&trim=1&use_submission_date=0)

Also changed the behavior for CSV/JSON export.

In a separate commit, fixed histogram caption not always appearing. I noticed this when testing the first commit.