### PR TITLE
Add `metric count` evolution plot; fixes #312.

### DIFF
--- a/new-pipeline/evo.html
+++ b/new-pipeline/evo.html
@@ -69,6 +69,10 @@
                 <figure class="col-md-12">
                     <div class="col-md-12" id="submissions"></div>
                 </figure>
+                <h2 id="sample-counts-title" style="font-size: 18px; margin-bottom: 0"></h2>
+                <figure class="col-md-12">
+                    <div class="col-md-12" id="sample-counts"></div>
+                </figure>
             </div>
         </div>
         <div class="row">

--- a/new-pipeline/src/evo.js
+++ b/new-pipeline/src/evo.js
@@ -33,6 +33,9 @@ var gMetaAggregates = [
   ["submissions", "Submissions", function (evolution) {
     return evolution.submissions();
   }, "#submissions"],
+  ["sample-count", "Sample count", function (evolution) {
+    return evolution.sampleCounts();
+  }, "#sample-counts"],
 ];
 var gAvailablaAggregates = gDefaultAggregates.concat(gMetaAggregates);
 
@@ -331,9 +334,8 @@ $(function () {
                   .show();
               }
 
-              $("#submissions-title")
-                .text($("#measure")
-                  .val() + " submissions");
+              $("#submissions-title").text($("#measure").val() + " submissions");
+              $("#sample-counts-title").text($("#measure").val() + " sample counts");
               $("#measure-description")
                 .text(evolutionDescription === null ? $(
                     "#measure")

--- a/v2/doc.md
+++ b/v2/doc.md
@@ -199,6 +199,12 @@ Returns a list of submission counts for each histogram in `someEvolutionInstance
 
 This is provided as a convenience method to make it easy to plot summary statistics for histogram evolutions.
 
+### `someEvolutionInstance.sampleCounts()`
+
+Returns a list of sample counts for each histogram in `someEvolutionInstance`, sorted by date (oldest to newest).
+
+This is provided as a convenience method to make it easy to plot summary statistics for histogram evolutions.
+
 ### `Telemetry.Histogram`
 
 Class used to represent a histogram. Instances of this class can be obtained from `someEvolutionInstance.histogram()`. This class should not be instantiated directly.

--- a/v2/telemetry.js
+++ b/v2/telemetry.js
@@ -312,6 +312,10 @@
       });
     };
 
+    Evolution.prototype.sampleCounts = function () {
+      return this.map(histogram => histogram.count);
+    };
+
     return Evolution;
   })();
 


### PR DESCRIPTION
Fixes #312.

Before: [link](https://telemetry.mozilla.org/new-pipeline/evo.html#!aggregates=median&cumulative=0&end_date=null&keys=&max_channel_version=nightly%252F58&measure=FX_TAB_SWITCH_UPDATE_MS&min_channel_version=nightly%252F55&processType=*&product=Firefox&sanitize=1&sort_keys=submissions&start_date=null&trim=1&use_submission_date=0)
After: [link](https://adrian17.github.io/telemetry-dashboard/new-pipeline/evo.html#!aggregates=median&cumulative=0&end_date=null&keys=&max_channel_version=nightly%252F58&measure=FX_TAB_SWITCH_UPDATE_MS&min_channel_version=nightly%252F55&processType=*&product=Firefox&sanitize=1&sort_keys=submissions&start_date=null&trim=1&use_submission_date=0)

Changes:
- the new plot is displayed under the the "submissions" plot.
- "submissions" option was removed from the aggregates multiselect. I didn't feel it's needed, since the submissions plot is always shown anyway
- a lot of refactors, just to make the actual feature implementation commit just 20 lines long

To consider:
- I'm 90% sure I got the "metric count" semantics right (it's equivalent to the `Sample Count` value in Distribution View), but it'd be nice if you made sure I did it right (see side question below)
- The new plot is almost identical to the submissions plot (with the exception of order of magnitude of values), which makes them look a bit weird. There may be a smarter way to draw these two, but I could figure out a good (and easy to implement) UX for that.
- is refactoring/reformatting/simplifying related code in feature PRs (see commit d634adef88718c2b121318874587730790d38764) like this OK, or is it too much code churn?

Side question: sometimes/often `metric count` < `ping count`. For example [distribution](https://telemetry.mozilla.org/new-pipeline/dist.html#!cumulative=0&end_date=2017-08-01&keys=__none__!__none__!__none__&max_channel_version=nightly%252F56&measure=BROWSER_IS_USER_DEFAULT&min_channel_version=nightly%252F55&os=Windows_NT%252C6.2&processType=*&product=Firefox&sanitize=1&sort_keys=submissions&start_date=2017-06-12&table=0&trim=1&use_submission_date=0), [evolution](https://adrian17.github.io/telemetry-dashboard/new-pipeline/evo.html#!aggregates=bucket-0!bucket-1!bucket-2&cumulative=0&end_date=null&keys=&max_channel_version=nightly%252F58&measure=BROWSER_IS_USER_DEFAULT&min_channel_version=nightly%252F55&processType=*&product=Firefox&sanitize=1&sort_keys=submissions&start_date=null&trim=1&use_submission_date=0). I don't get why exactly this can happen. Does the server report _all_ pings in the time range, even if they didn't have this value? (which also seems a bit strange, since 1. that would mean the `ping count` should be equal between metrics, but it isn't, and 2. being default browser is probably checked fairly early on?)