### PR TITLE
Histogram Simulator Link added to the Home Page under Other DashBoards

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,6 +105,9 @@
                     <a class="list-group-item" href="https://squarewave.github.io">
                         Background Hang Reporting <div class="dashboard-description">View browser hang information collected from Nightly users</div>
                     </a>
+                    <a class="list-group-item" href="histogram-simulator/">
+                        Histogram Simulator <div class="dashboard-description">Simulate histogram bucket widths</div>
+                    </a>
                     <span class="list-group-item disabled">
                         Addon Startup Correlations
                         <div class="dashboard-description">Please <a href="https://github.com/mozilla/telemetry-dashboard/issues">Report a Bug</a> if you require this data.</div>


### PR DESCRIPTION
@chutten changes can be viewed at https://ab0092.github.io/telemetry-dashboard/ 