### PR TITLE
bug 1411305 - Notify users that the unrepresentative release data's going away.

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,10 +26,10 @@
                 <a href="http://docs.telemetry.mozilla.org" class="btn" title="Docs" target="_blank">Telemetry Documentation</a>
             </form>
             <h2>Telemetry dashboards</h2>
-            <!-- <div class="error-msg">
-              We're currently experiencing an issue with the Measurement and Evolution Dashboards.
-              <a href="https://bugzil.la/1375921">More Details</a>
-            </div> -->
+            <div class="error-msg">
+                The small, unrepresentative sample population of release users will soon stop being aggregated.
+                For context, please read <a href="https://medium.com/@georg.fritzsche/data-preference-changes-in-firefox-58-2d5df9c428b5">this blog post</a>.
+            </div>
         </header>
         <div class="row">
             <div class="col-md-4">

--- a/new-pipeline/dist.html
+++ b/new-pipeline/dist.html
@@ -28,10 +28,10 @@
                 <span class="permalink-control"></span>
             </form>
             <h1>Measurement Dashboard</h1>
-            <!-- <div class="error-msg">
-              We're currently experiencing an issue with Measurement and Evolution Dashboards
-              <a href="https://bugzil.la/1375921">More Details</a>
-            </div> -->
+            <div class="error-msg">
+                The small, unrepresentative sample population of release users will soon stop being aggregated.
+                For context, please read <a href="https://medium.com/@georg.fritzsche/data-preference-changes-in-firefox-58-2d5df9c428b5">this blog post</a>.
+            </div>
         </header>
         <div class="row">
             <div class="col-md-12">

--- a/new-pipeline/evo.html
+++ b/new-pipeline/evo.html
@@ -27,10 +27,10 @@
                 <span class="permalink-control"></span>
             </form>
             <h1>Evolution Dashboard</h1>
-            <!-- <div class="error-msg">
-              We're currently experiencing an issue with the Measurement and Evolution Dashboards.
-              <a href="https://bugzil.la/1375921">More Details</a>
-            </div> -->
+            <div class="error-msg">
+                The small, unrepresentative sample population of release users will soon stop being aggregated.
+                For context, please read <a href="https://medium.com/@georg.fritzsche/data-preference-changes-in-firefox-58-2d5df9c428b5">this blog post</a>.
+            </div>
         </header>
         <div class="row">
             <div class="col-md-12">


### PR DESCRIPTION
'cause it is. Soonish.