### PR TITLE
Remove "release aggregates going away" notice from index

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,10 +26,10 @@
                 <a href="http://docs.telemetry.mozilla.org" class="btn" title="Docs" target="_blank">Telemetry Documentation</a>
             </form>
             <h2>Telemetry dashboards</h2>
-            <div class="error-msg">
+            <!-- <div class="error-msg">
                 The small, unrepresentative sample population of release users will soon stop being aggregated.
                 For context, please read <a href="https://medium.com/@georg.fritzsche/data-preference-changes-in-firefox-58-2d5df9c428b5">this blog post</a>.
-            </div>
+            </div> -->
         </header>
         <div class="row">
             <div class="col-md-4">


### PR DESCRIPTION
It's not 100% clear that it's only relevant to dist and evo.