### PR TITLE
Incremental improvements to TMO landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <title>Telemetry Dashboards</title>
+    <title>Telemetry portal</title>
 
     <!-- Bootstrap and supporting libraries -->
     <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
@@ -22,7 +22,7 @@
             <form class="navbar-form inline pull-right">
                 <a href="https://wiki.mozilla.org/Telemetry" class="btn" title="Wiki" target="_blank">Telemetry Wiki</a>
             </form>
-            <h2>Telemetry dashboards</h2>
+            <h2>Telemetry portal</h2>
             <!-- <div class="error-msg">
                 The small, unrepresentative sample population of release users will soon stop being aggregated.
                 For context, please read <a href="https://medium.com/@georg.fritzsche/data-preference-changes-in-firefox-58-2d5df9c428b5">this blog post</a>.

--- a/index.html
+++ b/index.html
@@ -44,13 +44,15 @@
                         <div class="dashboard-description">See what hardware Firefox users have.</div>
                     </a>
                     <a class="list-group-item" href="https://sql.telemetry.mozilla.org/">
-                        SQL Portal <div class="dashboard-description">Query telemetry data with SQL.</div>
+                        SQL Portal <span class="fa fa-lock"></span>
+                        <div class="dashboard-description">Query telemetry data with SQL.</div>
                     </a>
-                    <a class="list-group-item" href="https://analysis.telemetry.mozilla.org/">
-                        Analysis Portal <div class="dashboard-description">Analyze telemetry data with Spark.</div>
                     </a>
                     <a class="list-group-item" href="https://reports.telemetry.mozilla.org/">
                         Reports Portal <div class="dashboard-description">Explore data analyses &amp; reports.</div>
+                    <a class="list-group-item" href="https://analysis.telemetry.mozilla.org/">
+                        Analysis Portal <span class="fa fa-lock"></span>
+                        <div class="dashboard-description">Analyze telemetry data with Spark.</div>
                     </a>
                     <h3>Documentation</h3>
                     <a class="list-group-item" href="https://docs.telemetry.mozilla.org/">
@@ -103,7 +105,7 @@
                       <div class="dashboard-description">Find us in <i>#telemetry</i> on <i>irc.mozilla.org</i>.</div>
                     </a>
                     <a class="list-group-item" href="https://mozilla.slack.com/messages/C4D5ZA91B/">
-                      Join us on Slack
+                      Join us on Slack <span class="fa fa-lock"></span>
                       <div class="dashboard-description">Find us in <i>#fx-metrics</i> on Slack.</div>
                     </a>
                     <h3>Other dashboards</h3>

--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
         </header>
         <div class="row">
             <div class="col-md-4">
-                <h3>Main dashboards</h3>
+                <h3>Main tools</h3>
                 <div class="dashboard-list list-group" style="margin: 0">
                     <a class="list-group-item" href="new-pipeline/dist.html">
                         Measurement Dashboard
@@ -115,7 +115,7 @@
                       <div class="dashboard-description">Find us in <i>#fx-metrics</i> on Slack.</div>
                     </a>
                 </div>
-                <h3>Other dashboards</h3>
+                <h3>Other tools</h3>
                 <div class="dashboard-list list-group">
                     <a class="list-group-item" href="https://reports.telemetry.mozilla.org/">
                         Reports Portal <div class="dashboard-description">Explore data analyses &amp; reports.</div>

--- a/index.html
+++ b/index.html
@@ -65,6 +65,9 @@
                     <a class="list-group-item" href="https://georgf.github.io/fx-data-explorer/">
                         Probe dictionary <div class="dashboard-description">Find what probes are submitted from Firefox.</div>
                     </a>
+                    <a class="list-group-item" href="https://wiki.mozilla.org/Firefox/Shield">
+                        Shield docs <div class="dashboard-description">Learn how to run Shield studies &amp; experiments.</div>
+                    </a>
                 </div>
             </div>
             <div class="col-md-4">

--- a/index.html
+++ b/index.html
@@ -22,9 +22,6 @@
             <form class="navbar-form inline pull-right">
                 <a href="https://wiki.mozilla.org/Telemetry" class="btn" title="Wiki" target="_blank">Telemetry Wiki</a>
             </form>
-            <form class="navbar-form inline pull-right">
-                <a href="http://docs.telemetry.mozilla.org" class="btn" title="Docs" target="_blank">Telemetry Documentation</a>
-            </form>
             <h2>Telemetry dashboards</h2>
             <!-- <div class="error-msg">
                 The small, unrepresentative sample population of release users will soon stop being aggregated.
@@ -33,8 +30,8 @@
         </header>
         <div class="row">
             <div class="col-md-4">
-                <h3>Main dashboards</h3>
                 <div class="dashboard-list scrollable-dashboard-list list-group" style="margin: 0">
+                    <h3>Main dashboards</h3>
                     <a class="list-group-item" href="new-pipeline/dist.html">
                         Measurement Dashboard
                         <div class="dashboard-description">View measure distributions as histograms.</div>
@@ -54,6 +51,16 @@
                     </a>
                     <a class="list-group-item" href="https://reports.telemetry.mozilla.org/">
                         Reports Portal <div class="dashboard-description">Explore data analyses &amp; reports.</div>
+                    </a>
+                    <h3>Documentation</h3>
+                    <a class="list-group-item" href="https://docs.telemetry.mozilla.org/">
+                        Data docs <div class="dashboard-description">Find what data is available &amp; how to use it.</div>
+                    </a>
+                    <a class="list-group-item" href="https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/">
+                        Firefox Telemetry docs <div class="dashboard-description">Learn how to record data &amp; what data gets sent.</div>
+                    </a>
+                    <a class="list-group-item" href="https://georgf.github.io/fx-data-explorer/">
+                        Probe dictionary <div class="dashboard-description">Find what probes are submitted from Firefox.</div>
                     </a>
                 </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -47,6 +47,9 @@
                         SQL Portal <span class="fa fa-lock"></span>
                         <div class="dashboard-description">Query telemetry data with SQL.</div>
                     </a>
+                    <a class="list-group-item" href="https://moz-experiments-viewer.herokuapp.com/">
+                        Experiments viewer <span class="fa fa-lock"></span>
+                        <div class="dashboard-description">See the impact of different experiments have on our metrics.</div>
                     </a>
                     <a class="list-group-item" href="https://reports.telemetry.mozilla.org/">
                         Reports Portal <div class="dashboard-description">Explore data analyses &amp; reports.</div>

--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
                     </a>
                     <a class="list-group-item" href="https://moz-experiments-viewer.herokuapp.com/">
                         Experiments viewer <span class="fa fa-lock"></span>
-                        <div class="dashboard-description">See the impact of different experiments have on our metrics.</div>
+                        <div class="dashboard-description">See the impact different experiments have.</div>
                     </a>
                     <a class="list-group-item" href="https://analysis.telemetry.mozilla.org/">
                         Analysis Portal <span class="fa fa-lock"></span>

--- a/index.html
+++ b/index.html
@@ -142,40 +142,8 @@
                         Histogram Simulator <div class="dashboard-description">Simulate histogram bucket widths</div>
                     </a>
                     <span class="list-group-item disabled">
-                        Addon Startup Correlations
-                        <div class="dashboard-description">Please <a href="https://github.com/mozilla/telemetry-dashboard/issues">Report a Bug</a> if you require this data.</div>
-                    </span>
-                    <span class="list-group-item disabled">
-                        Addon Shutdown Correlations
-                        <div class="dashboard-description">Please <a href="https://github.com/mozilla/telemetry-dashboard/issues">Report a Bug</a> if you require this data.</div>
-                    </span>
-                    <span class="list-group-item disabled">
-                        Chrome Hangs
-                        <div class="dashboard-description">Please <a href="https://github.com/mozilla/telemetry-dashboard/issues">Report a Bug</a> if you require this data.</div>
-                    </span>
-                    <span class="list-group-item disabled">
-                        Fennec App Not Responding (ANR)
-                        <div class="dashboard-description">Please <a href="https://github.com/mozilla/telemetry-dashboard/issues">Report a Bug</a> if you require this data.</div>
-                    </span>
-                    <span class="list-group-item disabled">
-                        Fennec UI Telemetry
-                        <div class="dashboard-description">Please <a href="https://github.com/mozilla/telemetry-dashboard/issues">Report a Bug</a> if you require this data.</div>
-                    </span>
-                    <span class="list-group-item disabled">
-                        Firefox UI Telemetry
-                        <div class="dashboard-description">Please <a href="https://github.com/mozilla/telemetry-dashboard/issues">Report a Bug</a> if you require this data.</div>
-                    </span>
-                    <span class="list-group-item disabled">
-                        Main Thread I/O
-                        <div class="dashboard-description">Please <a href="https://github.com/mozilla/telemetry-dashboard/issues">Report a Bug</a> if you require this data.</div>
-                    </span>
-                    <span class="list-group-item disabled">
-                        Power Dashboard <span class="label label-warning" style="font-size: 12px">DRAFT</span>
-                        <div class="dashboard-description">Please <a href="https://github.com/mozilla/telemetry-dashboard/issues">Report a Bug</a> if you require this data.</div>
-                    </span>
-                    <span class="list-group-item disabled">
-                        SlowSQL
-                        <div class="dashboard-description">Please <a href="https://github.com/mozilla/telemetry-dashboard/issues">Report a Bug</a> if you require this data.</div>
+                        Missing something?
+                        <div class="dashboard-description">Please <a href="https://github.com/mozilla/telemetry-dashboard/issues">Report a Bug</a> if you are missing a dashboard here.</div>
                     </span>
                 </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
                     </a>
                     <a class="list-group-item" href="https://metrics.mozilla.com/firefox-hardware-report/">
                         Firefox Hardware Report
-                        <div class="dashboard-description">View the Firefox user population categorized by hardware specifications.</div>
+                        <div class="dashboard-description">See what hardware Firefox users have.</div>
                     </a>
                     <a class="list-group-item" href="https://sql.telemetry.mozilla.org/">
                         SQL Portal <div class="dashboard-description">Query telemetry data with SQL.</div>

--- a/index.html
+++ b/index.html
@@ -42,6 +42,10 @@
                     <a class="list-group-item" href="new-pipeline/evo.html">
                         Evolution Dashboard <div class="dashboard-description">View evolution of measure values over time.</div>
                     </a>
+                    <a class="list-group-item" href="https://metrics.mozilla.com/firefox-hardware-report/">
+                        Firefox Hardware Report
+                        <div class="dashboard-description">View the Firefox user population categorized by hardware specifications.</div>
+                    </a>
                     <a class="list-group-item" href="https://sql.telemetry.mozilla.org/">
                         SQL Portal <div class="dashboard-description">Query telemetry data with SQL.</div>
                     </a>
@@ -85,10 +89,6 @@
                     </a>
                     <a class="list-group-item" href="https://bsmedberg.github.io/telemetry-experiments-dashboard/">
                         Experiment Monitoring <div class="dashboard-description">View vitals and statistics for Firefox Telemetry Experiments.</div>
-                    </a>
-                    <a class="list-group-item" href="https://metrics.mozilla.com/firefox-hardware-report/">
-                        Firefox Hardware Report
-                        <div class="dashboard-description">View the Firefox user population categorized by hardware specifications.</div>
                     </a>
                     <a class="list-group-item" href="http://alerts.telemetry.mozilla.org/">
                         Telemetry Alerts <div class="dashboard-description">Set up email alerts for significant performance changes.</div>

--- a/index.html
+++ b/index.html
@@ -51,8 +51,6 @@
                         Experiments viewer <span class="fa fa-lock"></span>
                         <div class="dashboard-description">See the impact of different experiments have on our metrics.</div>
                     </a>
-                    <a class="list-group-item" href="https://reports.telemetry.mozilla.org/">
-                        Reports Portal <div class="dashboard-description">Explore data analyses &amp; reports.</div>
                     <a class="list-group-item" href="https://analysis.telemetry.mozilla.org/">
                         Analysis Portal <span class="fa fa-lock"></span>
                         <div class="dashboard-description">Analyze telemetry data with Spark.</div>
@@ -112,6 +110,9 @@
                       <div class="dashboard-description">Find us in <i>#fx-metrics</i> on Slack.</div>
                     </a>
                     <h3>Other dashboards</h3>
+                    <a class="list-group-item" href="https://reports.telemetry.mozilla.org/">
+                        Reports Portal <div class="dashboard-description">Explore data analyses &amp; reports.</div>
+                    </a>
                     <a class="list-group-item" href="dashboard-generator/index.html">
                       Dashboard Generator
                       <div class="dashboard-description">Hand-craft your own dashboard with the push of a few buttons</div>

--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
         </header>
         <div class="row">
             <div class="col-md-4">
-                <div class="dashboard-list scrollable-dashboard-list list-group" style="margin: 0">
+                <div class="dashboard-list list-group" style="margin: 0">
                     <h3>Main dashboards</h3>
                     <a class="list-group-item" href="new-pipeline/dist.html">
                         Measurement Dashboard
@@ -94,7 +94,7 @@
                 </div>
             </div>
             <div class="col-md-4">
-                <div class="dashboard-list scrollable-dashboard-list list-group">
+                <div class="dashboard-list list-group">
                     <h3>Getting help</h3>
                     <a class="list-group-item" href="https://mail.mozilla.org/listinfo/fx-data-dev">
                       Join the mailing list

--- a/index.html
+++ b/index.html
@@ -120,6 +120,10 @@
                     <a class="list-group-item" href="https://reports.telemetry.mozilla.org/">
                         Reports Portal <div class="dashboard-description">Explore data analyses &amp; reports.</div>
                     </a>
+                    <a class="list-group-item" href="https://sso.mozilla.com/amplitude">
+                        Amplitude <span class="fa fa-lock"></span>
+                        <div class="dashboard-description">Dive into product analytics.</div>
+                    </a>
                     <a class="list-group-item" href="dashboard-generator/index.html">
                       Dashboard Generator
                       <div class="dashboard-description">Hand-craft your own dashboard with the push of a few buttons</div>

--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@
                 </div>
             </div>
             <div class="col-md-4">
-                <h3>Telemetry @ Twitter</h3>
+                <h3>What is new</h3>
                 <!-- Twitter widget -->
                 <div>
                     <a class="twitter-timeline"
@@ -92,7 +92,7 @@
                     <h3>Getting help</h3>
                     <a class="list-group-item" href="https://mail.mozilla.org/listinfo/fx-data-dev">
                       Join the mailing list
-                      <div class="dashboard-description">Get help on data topics.</div>
+                      <div class="dashboard-description">Get help on data topics and upcoming changes.</div>
                     </a>
                     <a class="list-group-item" href="https://bugzilla.mozilla.org/enter_bug.cgi?product=Data%20Platform%20and%20Tools&component=General">
                       File a bug

--- a/index.html
+++ b/index.html
@@ -68,7 +68,7 @@
                 </div>
             </div>
             <div class="col-md-4">
-                <h3>What is new</h3>
+                <h3>What's new</h3>
                 <!-- Twitter widget -->
                 <div>
                     <a class="twitter-timeline"

--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
                         <div class="dashboard-description">View dashboards &amp; run SQL queries.</div>
                     </a>
                     <a class="list-group-item" href="https://moz-experiments-viewer.herokuapp.com/">
-                        Experiments viewer <span class="fa fa-lock"></span>
+                        Experiments Viewer <span class="fa fa-lock"></span>
                         <div class="dashboard-description">See the impact different experiments have.</div>
                     </a>
                     <a class="list-group-item" href="https://analysis.telemetry.mozilla.org/">
@@ -56,16 +56,16 @@
                 <h3>Documentation</h3>
                 <div class="dashboard-list list-group" style="margin: 0">
                     <a class="list-group-item" href="https://docs.telemetry.mozilla.org/">
-                        Data docs <div class="dashboard-description">Find what data is available &amp; how to use it.</div>
+                        Data Docs <div class="dashboard-description">Find what data is available &amp; how to use it.</div>
                     </a>
                     <a class="list-group-item" href="https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/">
-                        Firefox Telemetry docs <div class="dashboard-description">Learn how to record data &amp; what data gets sent.</div>
+                        Firefox Telemetry Docs <div class="dashboard-description">Learn how to record data &amp; what data gets sent.</div>
                     </a>
                     <a class="list-group-item" href="https://georgf.github.io/fx-data-explorer/">
-                        Probe dictionary <div class="dashboard-description">Find what probes are submitted from Firefox.</div>
+                        Probe Dictionary <div class="dashboard-description">Find what probes are submitted from Firefox.</div>
                     </a>
                     <a class="list-group-item" href="https://wiki.mozilla.org/Firefox/Shield">
-                        Shield docs <div class="dashboard-description">Learn how to run Shield studies &amp; experiments.</div>
+                        Shield Docs <div class="dashboard-description">Learn how to run Shield studies &amp; experiments.</div>
                     </a>
                 </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -30,8 +30,8 @@
         </header>
         <div class="row">
             <div class="col-md-4">
+                <h3>Main dashboards</h3>
                 <div class="dashboard-list list-group" style="margin: 0">
-                    <h3>Main dashboards</h3>
                     <a class="list-group-item" href="new-pipeline/dist.html">
                         Measurement Dashboard
                         <div class="dashboard-description">View measure distributions as histograms.</div>
@@ -55,7 +55,9 @@
                         Analysis Portal <span class="fa fa-lock"></span>
                         <div class="dashboard-description">Analyze telemetry data with Spark.</div>
                     </a>
-                    <h3>Documentation</h3>
+                </div>
+                <h3>Documentation</h3>
+                <div class="dashboard-list list-group" style="margin: 0">
                     <a class="list-group-item" href="https://docs.telemetry.mozilla.org/">
                         Data docs <div class="dashboard-description">Find what data is available &amp; how to use it.</div>
                     </a>
@@ -94,8 +96,8 @@
                 </div>
             </div>
             <div class="col-md-4">
+                <h3>Getting help</h3>
                 <div class="dashboard-list list-group">
-                    <h3>Getting help</h3>
                     <a class="list-group-item" href="https://mail.mozilla.org/listinfo/fx-data-dev">
                       Join the mailing list
                       <div class="dashboard-description">Get help on data topics and upcoming changes.</div>
@@ -112,7 +114,9 @@
                       Join us on Slack <span class="fa fa-lock"></span>
                       <div class="dashboard-description">Find us in <i>#fx-metrics</i> on Slack.</div>
                     </a>
-                    <h3>Other dashboards</h3>
+                </div>
+                <h3>Other dashboards</h3>
+                <div class="dashboard-list list-group">
                     <a class="list-group-item" href="https://reports.telemetry.mozilla.org/">
                         Reports Portal <div class="dashboard-description">Explore data analyses &amp; reports.</div>
                     </a>

--- a/index.html
+++ b/index.html
@@ -88,8 +88,25 @@
                 </div>
             </div>
             <div class="col-md-4">
-                <h3>Other dashboards</h3>
                 <div class="dashboard-list scrollable-dashboard-list list-group">
+                    <h3>Getting help</h3>
+                    <a class="list-group-item" href="https://mail.mozilla.org/listinfo/fx-data-dev">
+                      Join the mailing list
+                      <div class="dashboard-description">Get help on data topics.</div>
+                    </a>
+                    <a class="list-group-item" href="https://bugzilla.mozilla.org/enter_bug.cgi?product=Data%20Platform%20and%20Tools&component=General">
+                      File a bug
+                      <div class="dashboard-description">File a bug with details on <i>bugzilla.mozilla.org</i>.</div>
+                    </a>
+                    <a class="list-group-item" href="https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23telemetry">
+                      Chat on IRC
+                      <div class="dashboard-description">Find us in <i>#telemetry</i> on <i>irc.mozilla.org</i>.</div>
+                    </a>
+                    <a class="list-group-item" href="https://mozilla.slack.com/messages/C4D5ZA91B/">
+                      Join us on Slack
+                      <div class="dashboard-description">Find us in <i>#fx-metrics</i> on Slack.</div>
+                    </a>
+                    <h3>Other dashboards</h3>
                     <a class="list-group-item" href="dashboard-generator/index.html">
                       Dashboard Generator
                       <div class="dashboard-description">Hand-craft your own dashboard with the push of a few buttons</div>

--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
                     </a>
                     <a class="list-group-item" href="https://sql.telemetry.mozilla.org/">
                         SQL Portal <span class="fa fa-lock"></span>
-                        <div class="dashboard-description">Query telemetry data with SQL.</div>
+                        <div class="dashboard-description">View dashboards &amp; run SQL queries.</div>
                     </a>
                     <a class="list-group-item" href="https://moz-experiments-viewer.herokuapp.com/">
                         Experiments viewer <span class="fa fa-lock"></span>

--- a/index.html
+++ b/index.html
@@ -146,10 +146,6 @@
                     <a class="list-group-item" href="histogram-simulator/">
                         Histogram Simulator <div class="dashboard-description">Simulate histogram bucket widths</div>
                     </a>
-                    <span class="list-group-item disabled">
-                        Missing something?
-                        <div class="dashboard-description">Please <a href="https://github.com/mozilla/telemetry-dashboard/issues">Report a Bug</a> if you are missing a dashboard here.</div>
-                    </span>
                 </div>
             </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -19,9 +19,6 @@
             <form class="navbar-form inline pull-right">
                 <a href="https://github.com/mozilla/telemetry-dashboard/issues" class="btn" title="Report bugs in Telemetry dashboards" target="_blank">Report bug</a>
             </form>
-            <form class="navbar-form inline pull-right">
-                <a href="https://wiki.mozilla.org/Telemetry" class="btn" title="Wiki" target="_blank">Telemetry Wiki</a>
-            </form>
             <h2>Telemetry portal</h2>
             <!-- <div class="error-msg">
                 The small, unrepresentative sample population of release users will soon stop being aggregated.

--- a/style/dashboards.css
+++ b/style/dashboards.css
@@ -19,7 +19,7 @@
 }
 .big-dashboard-list .list-group-item .dashboard-description { font-size: 18px; }
 .scrollable-dashboard-list {
-  height: 600px;
+  height: 700px;
   overflow-y: auto;
 }
 .scrollable-dashboard-list .list-group-item {

--- a/style/dashboards.css
+++ b/style/dashboards.css
@@ -22,15 +22,6 @@
   border-top: 1px solid #ddd;
 }
 .big-dashboard-list .list-group-item .dashboard-description { font-size: 18px; }
-.scrollable-dashboard-list {
-  height: 700px;
-  overflow-y: auto;
-}
-.scrollable-dashboard-list .list-group-item {
-  border: none;
-  border-top: 1px solid #ddd;
-}
-.scrollable-dashboard-list .list-group-item:first-child { border-top: none; }
 
 /* Dropdown style overrides */
 .multiselect {

--- a/style/dashboards.css
+++ b/style/dashboards.css
@@ -17,6 +17,10 @@
   background: #326AA7;
   color: white;
 }
+.dashboard-list .list-group-item {
+  border: none;
+  border-top: 1px solid #ddd;
+}
 .big-dashboard-list .list-group-item .dashboard-description { font-size: 18px; }
 .scrollable-dashboard-list {
   height: 700px;

--- a/style/dashboards.css
+++ b/style/dashboards.css
@@ -21,6 +21,9 @@
   border: none;
   border-top: 1px solid #ddd;
 }
+.dashboard-list .list-group-item:first-child {
+  border-top: none;
+}
 .big-dashboard-list .list-group-item .dashboard-description { font-size: 18px; }
 
 /* Dropdown style overrides */


### PR DESCRIPTION
Following up on initial insights from user interviews and a planning meeting, i want to put out some short-term & cheap fixes to the current landing page.
This would help us with highlighting the page as the "go to" page for Telemetry & data things in Austin.

We definitely want to do a proper re-design later, but that doesn't seem feasible in the short term.
I played around with some smaller changes, you can see them live [here](https://georgf.github.io/telemetry-dashboard/).

To summarize:
- added a lock icon to LDAP protected pages
- moved the hardware report to main dashboards & reports.tmo out of it
- added a docs section, with links to docs.tmo, client docs & the probe explorer
- added a getting help section with links to our communication channels

I'm not happy with the layout changes, feedback appreciated. Specifically i can't add two `scrollable-dashboard-list` to one column as the second one gets squashed to the bottom, that's why i moved the `h3`s inside one list.