### PR TITLE
Remove only target="_blank" usage

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
     <div class="container-fluid">
         <header>
             <form class="navbar-form inline pull-right">
-                <a href="https://github.com/mozilla/telemetry-dashboard/issues" class="btn" title="Report bugs in Telemetry dashboards" target="_blank">Report bug</a>
+                <a href="https://github.com/mozilla/telemetry-dashboard/issues" class="btn" title="Report bugs in Telemetry dashboards">Report bug</a>
             </form>
             <h2>Telemetry portal</h2>
             <!-- <div class="error-msg">


### PR DESCRIPTION
This is the only place that is using target=“_blank”.
Erik caught that this is inconsistent and should probably just have
standard behaviour.