### PR TITLE
bug 1293750 - Add Google Analytics to telemetry.mozilla.org

### DIFF
--- a/addon-perf/index.html
+++ b/addon-perf/index.html
@@ -12,14 +12,8 @@
     <script type="text/javascript" src="/lib/jquery.csv-0.8.2.js"></script>
     <link rel="stylesheet" href="addon-perf.css" />
     <link rel="stylesheet" href="http://code.jquery.com/ui/1.10.4/themes/smoothness/jquery-ui.css">
-    <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-      ga('create', 'UA-49796218-2', 'mozilla.org');
-      ga('send', 'pageview');
-    </script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-49796218-2"></script>
+    <script src="../analytics/analytics.js"></script>
 </head>
 <body>
 <!--
@@ -143,6 +137,7 @@
     </div>
 </div>
 <div id='footer'></div>
+<div><a href="https://www.mozilla.org/en-US/privacy/websites/">Mozilla's Website Privacy Notice</a></div>
 </body>
 </html>
 

--- a/addon-recommender/index.html
+++ b/addon-recommender/index.html
@@ -10,6 +10,8 @@
     <link href="css/bootstrap.min.css" rel="stylesheet">
     <link href="css/select2.min.css" rel="stylesheet"/>
     <link href="css/select2-bootstrap.css" rel="stylesheet"/>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-49796218-2"></script>
+    <script src="../analytics/analytics.js"></script>
   </head>
   <body>
     <script src="js/jquery.min.js"></script>
@@ -68,5 +70,6 @@
         </div>
       </div>
     </div>
+    <div><a href="https://www.mozilla.org/en-US/privacy/websites/">Mozilla's Website Privacy Notice</a></div>
   </body>
 </html>

--- a/analytics/analytics.js
+++ b/analytics/analytics.js
@@ -1,0 +1,29 @@
+(function() {
+
+window.trackingEnabled = () => {
+  var _dntStatus = navigator.doNotTrack || navigator.msDoNotTrack;
+  var fx = navigator.userAgent.match(/Firefox\/(\d+)/);
+  var ie10 = navigator.userAgent.match(/MSIE 10/i);
+  var w8 = navigator.appVersion.match(/Windows NT 6.2/);
+  if (fx && Number(fx[1]) < 32) {
+    _dntStatus = 'Unspecified'; // bug 887703
+  } else if (ie10 && w8) {
+    _dntStatus = 'Unspecified';
+  } else {
+    _dntStatus = {'0': 'Disabled', '1': 'Enabled'}[_dntStatus] || 'Unspecified';
+  }
+
+  window.trackingEnabled = () => {
+    return _dntStatus != 'Enabled';
+  }
+  return window.trackingEnabled();
+};
+
+if (window.trackingEnabled()) {
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'UA-49796218-2');
+}
+
+}());

--- a/crashes/index.html
+++ b/crashes/index.html
@@ -15,6 +15,8 @@
 
 <script src="thresholds.js"></script>
 <script src="latest-versions.js"></script>
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-49796218-2"></script>
+<script src="../analytics/analytics.js"></script>
 </head>
 <body>
 <h1>Stability Dashboard</h1>
@@ -425,5 +427,6 @@ xhr.addEventListener("error", () => {
 xhr.open("GET", "https://sql.telemetry.mozilla.org/api/queries/1092/results.json?api_key=f7dac61893e040ca59c76fd616f082479e2a1c85");
 xhr.send();
 </script>
+<div><a href="https://www.mozilla.org/en-US/privacy/websites/">Mozilla's Website Privacy Notice</a></div>
 </body>
 </html>

--- a/dashboard-generator/index.html
+++ b/dashboard-generator/index.html
@@ -13,6 +13,8 @@
 
 <script src="https://telemetry.mozilla.org/v2/telemetry.js"></script>
 <script src="generator.js"></script>
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-49796218-2"></script>
+<script src="../analytics/analytics.js"></script>
 </head>
 <body>
 <header>
@@ -133,5 +135,6 @@
     <button autocomplete="off" id="generate" type="submit" disabled>Generate Dashboard</button>
   </form>
 </main>
+<div><a href="https://www.mozilla.org/en-US/privacy/websites/">Mozilla's Website Privacy Notice</a></div>
 </body>
 </html>

--- a/histogram-simulator/index.html
+++ b/histogram-simulator/index.html
@@ -25,6 +25,8 @@ input[type=number] { -moz-appearance: textfield; }
 
 input { margin-top: 3px; }
     </style>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-49796218-2"></script>
+    <script src="../analytics/analytics.js"></script>
 </head>
 <body>
     <div class="container-fluid">
@@ -76,6 +78,7 @@ input { margin-top: 3px; }
             </figure>
         </div>
     </div>
+    <div><a href="https://www.mozilla.org/en-US/privacy/websites/">Mozilla's Website Privacy Notice</a></div>
     
     <script src="//code.jquery.com/jquery-1.11.3.min.js"></script>
     <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>

--- a/index.html
+++ b/index.html
@@ -12,6 +12,8 @@
     <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
 
     <link rel="stylesheet" href="style/dashboards.css">
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-49796218-2"></script>
+    <script src="analytics/analytics.js"></script>
 </head>
 <body>
     <div class="container-fluid">
@@ -150,6 +152,7 @@
             </div>
         </div>
     </div>
+    <div><a href=https://www.mozilla.org/en-US/privacy/websites/">Mozilla's Website Privacy Notice</a></div>
 
     <!-- Bootstrap and supporting libraries -->
     <script src="//code.jquery.com/jquery-1.11.3.min.js"></script>

--- a/new-pipeline/dist.html
+++ b/new-pipeline/dist.html
@@ -16,6 +16,8 @@
     <link rel="stylesheet" type="text/css" href="style/metricsgraphics.css" />
     
     <link rel="stylesheet" type="text/css" href="style/dashboards.css" />
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-49796218-2"></script>
+    <script src="../analytics/analytics.js"></script>
 </head>
 <body>
     <div class="container-fluid">
@@ -189,6 +191,7 @@
         <i style="margin: 0 5px" class="fa fa-cog fa-spin"></i>
         <span class="busy-indicator-message">Loading page...</span>
     </div>
+    <div><a href="https://www.mozilla.org/en-US/privacy/websites/">Mozilla's Website Privacy Notice</a></div>
     
     <!-- Bootstrap and supporting libraries -->
     <script src="//code.jquery.com/jquery-1.11.3.min.js"></script>

--- a/new-pipeline/evo.html
+++ b/new-pipeline/evo.html
@@ -15,6 +15,8 @@
     <link rel="stylesheet" type="text/css" href="style/metricsgraphics.css" />
     
     <link rel="stylesheet" type="text/css" href="style/dashboards.css" />
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-49796218-2"></script>
+    <script src="../analytics/analytics.js"></script>
 </head>
 <body>
     <div class="container-fluid">
@@ -106,7 +108,7 @@
         <i class="fa fa-cog fa-spin"></i>
         <span class="busy-indicator-message">Loading page...</span>
     </div>
-
+    <div><a href="https://www.mozilla.org/en-US/privacy/websites/">Mozilla's Website Privacy Notice</a></div>
     
     <!-- Bootstrap and supporting libraries -->
     <script src="//code.jquery.com/jquery-1.11.3.min.js"></script>

--- a/new-pipeline/tutorial.html
+++ b/new-pipeline/tutorial.html
@@ -14,6 +14,8 @@
     <style>
     #tocify-header0 > .tocify-item { font-weight: bold; } /* bold the top-level entries */
     </style>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-49796218-2"></script>
+    <script src="../analytics/analytics.js"></script>
 </head>
 <body>
     <form id="histogram-filters" class="navbar-form inline" style="position: fixed; right: 1em; top: 1em; z-index: 1">
@@ -158,6 +160,7 @@
             </div>
         </div>
     </div>
+    <div><a href="https://www.mozilla.org/en-US/privacy/websites/">Mozilla's Website Privacy Notice</a></div>
 
     <!-- Bootstrap and supporting libraries -->
     <script src="//code.jquery.com/jquery-1.11.3.min.js"></script>

--- a/update-orphaning/index.html
+++ b/update-orphaning/index.html
@@ -8,6 +8,8 @@
 <script type="text/javascript" src="https://d3js.org/d3.v3.min.js" charset="utf-8"></script>
 <script type="text/javascript" src="https://telemetry.mozilla.org/new-pipeline/lib/d3pie.min.js"></script>
 <script type="text/javascript" src="index.js" charset="utf-8"></script>
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-49796218-2"></script>
+<script src="../analytics/analytics.js"></script>
 </head>
 <body onload="initDashboard()">
 <div id="weekly-dropdown-div">
@@ -96,6 +98,8 @@ criteria are applied is the same order as they are listed below.</div>
 <hr>
 This dashboard is maintained by <a href="mailto:rstrong@mozilla.com">:rstrong</a>.<br/>
 The Spark Notebook for the weekly reports is scheduled to run every Sunday and can be found <a href="https://github.com/mozilla/mozilla-reports/tree/master/projects/app_update_out_of_date.kp/orig_src/app_update_out_of_date.ipynb">here</a>.
+
+<div><a href="https://www.mozilla.org/en-US/privacy/websites/">Mozilla's Website Privacy Notice</a></div>
 </div>
 </body>
 </html>


### PR DESCRIPTION
We don't know where users come from or go to on TMO, and that's an odd sort of
lapse for a data-based web application.

This is preliminary: just gtags for now.