### PR TITLE
Histogram comparison statistics

### DIFF
--- a/new-pipeline/dist.html
+++ b/new-pipeline/dist.html
@@ -4,9 +4,9 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    
+
     <title>Measurement Dashboard</title>
-    
+
     <!-- Bootstrap and supporting libraries -->
     <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
     <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
@@ -14,7 +14,7 @@
     <link rel="stylesheet" type="text/css" href="lib/daterangepicker-bs3.css" />
     <link rel="stylesheet" type="text/css" href="style/elessar.css" />
     <link rel="stylesheet" type="text/css" href="style/metricsgraphics.css" />
-    
+
     <link rel="stylesheet" type="text/css" href="style/dashboards.css" />
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-49796218-2"></script>
     <script src="../analytics/analytics.js"></script>
@@ -118,6 +118,13 @@
                                 </dl>
                             </div>
                         </div>
+                        <div id="stats-comparison">
+                            <div class="scalar-only" style="margin-top: 50px">
+                                <dl class="dl-horizontal" id="medians">
+                                    <dt>Median</dt><dd id="prop-p50"></dd>
+                                </dl>
+                            </div>
+                        </div>
                         <div style="text-align: center">
                             <a class="btn btn-default btn-sm" id="export-csv" title="Export the current histogram to CSV">Export CSV</a>
                             <a class="btn btn-default btn-sm" id="export-json" title="Export the current histogram to JSON">Export JSON</a>
@@ -192,7 +199,7 @@
         <span class="busy-indicator-message">Loading page...</span>
     </div>
     <div><a href="https://www.mozilla.org/en-US/privacy/websites/">Mozilla's Website Privacy Notice</a></div>
-    
+
     <!-- Bootstrap and supporting libraries -->
     <script src="//code.jquery.com/jquery-1.11.3.min.js"></script>
     <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
@@ -200,12 +207,12 @@
     <script src="//cdnjs.cloudflare.com/ajax/libs/moment.js/2.10.2/moment.min.js"></script>
     <script type="text/javascript" src="lib/daterangepicker.js"></script>
     <script src="lib/elessar.min.js"></script>
-    
+
     <!-- MetricsGraphics libraries -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.5/d3.min.js" charset="utf-8"></script>
     <script src="lib/metricsgraphics.js"></script>
     <script src="lib/d3pie.min.js"></script>
-    
+
     <script src="../v2/telemetry.js"></script>
     <script src="src/dashboards.js"></script>
     <script src="src/dist.js"></script>

--- a/new-pipeline/dist.html
+++ b/new-pipeline/dist.html
@@ -118,12 +118,24 @@
                                 </dl>
                             </div>
                         </div>
-                        <div id="stats-comparison">
-                            <div class="scalar-only" style="margin-top: 50px">
-                                <dl class="dl-horizontal" id="medians">
-                                    <dt>Median</dt><dd id="prop-p50"></dd>
-                                </dl>
-                            </div>
+                        <div id="stats-comparison" style="margin-top: 50px; margin-bottom: 20px;">
+                            <table>
+                              <thead class="measure-headers">
+                              <tr>
+                              <th></th>
+                              <th title="5th percentile duration">5 %</th>
+                              <th title="25th percentile duration">25 %</th>
+                              <th title="Median duration">Median</th>
+                              <th title="75th percentile duration">75 %</th>
+                              <th title="95th percentile duration">95 %</th>
+                              </tr>
+                              </thead>
+                              <tbody id="histogram-percentiles" class="measure-values">
+                                  <tr>
+                                  <td colspan="6">No Data</td>
+                                  </tr>
+                              </tbody>
+                            </table>
                         </div>
                         <div style="text-align: center">
                             <a class="btn btn-default btn-sm" id="export-csv" title="Export the current histogram to CSV">Export CSV</a>

--- a/new-pipeline/src/dist.js
+++ b/new-pipeline/src/dist.js
@@ -935,13 +935,18 @@ function displayHistograms(histogramsList, dates, useTable, cumulative, trim) {
         .hide();
 
     } else {
-      $("#medians")
+      $("#histogram-percentiles")
         .empty()
         .append(
           histogramsList[0].histograms.map(function(histogram) {
-            $measure = $("<dt></dt>").text(histogram.measure + " Median");
-            $value = $("<dd></dd>").text(formatNumber(histogram.percentile(50)));
-            return $measure.add($value);
+            return `<tr>
+            <th>${histogram.measure}</th>
+            <td>${formatNumber(histogram.percentile(5))}</td>
+            <td>${formatNumber(histogram.percentile(25))}</td>
+            <td>${formatNumber(histogram.percentile(50))}</td>
+            <td>${formatNumber(histogram.percentile(75))}</td>
+            <td>${formatNumber(histogram.percentile(95))}</td>
+            </tr>`;
           })
         );
       $("#summary")

--- a/new-pipeline/src/dist.js
+++ b/new-pipeline/src/dist.js
@@ -931,10 +931,23 @@ function displayHistograms(histogramsList, dates, useTable, cumulative, trim) {
       }
       $("#summary")
         .show();
+      $("#stats-comparison")
+        .hide();
 
     } else {
+      $("#medians")
+        .empty()
+        .append(
+          histogramsList[0].histograms.map(function(histogram) {
+            $measure = $("<dt></dt>").text(histogram.measure + " Median");
+            $value = $("<dd></dd>").text(formatNumber(histogram.percentile(50)));
+            return $measure.add($value);
+          })
+        );
       $("#summary")
         .hide();
+      $("#stats-comparison")
+        .show();
     }
 
     $("#plots")
@@ -973,6 +986,8 @@ function displayHistograms(histogramsList, dates, useTable, cumulative, trim) {
     }
   } else { // Show all four axes
     $("#summary")
+      .hide();
+    $("#stats-comparison")
       .hide();
     $("#plots")
       .removeClass("col-md-9")

--- a/new-pipeline/style/dashboards.css
+++ b/new-pipeline/style/dashboards.css
@@ -142,3 +142,15 @@
 .error-msg:empty {
   display: none;
 }
+
+/* Histogram statistics */
+.measure-headers, .measure-values {
+  font-size: 0.8em;
+}
+.measure-values td {
+  padding-left: 0.5em;
+  text-align: right;
+}
+.measure-headers th {
+  text-align: right;
+}


### PR DESCRIPTION
Resolves https://github.com/mozilla/telemetry-dashboard/issues/274

Display table with percentiles in the empty space next to the histograms when performing a comparison.

@chutten for review