### PR TITLE
Extended the expiry of the 'this is my current dashboard state' cookie to 28 days

### DIFF
--- a/new-pipeline/src/dist.js
+++ b/new-pipeline/src/dist.js
@@ -1728,9 +1728,9 @@ function saveStateToUrlAndCookie() {
       .hide(); // Hide the permalink box again since the URL changed
   }
 
-  // Save the state in a cookie that expires in 3 days
+  // Save the state in a cookie that expires in 28 days
   var expiry = new Date();
-  expiry.setTime(expiry.getTime() + (3 * 24 * 60 * 60 * 1000));
+  expiry.setTime(expiry.getTime() + (28 * 24 * 60 * 60 * 1000));
   document.cookie = "stateFromUrl=" + stateString + "; expires=" + expiry.toGMTString();
 
   // Add link to switch to the evolution dashboard with the same settings

--- a/new-pipeline/src/evo.js
+++ b/new-pipeline/src/evo.js
@@ -1062,9 +1062,9 @@ function saveStateToUrlAndCookie() {
       .hide(); // Hide the permalink box again since the URL changed
   }
 
-  // Save the state in a cookie that expires in 3 days
+  // Save the state in a cookie that expires in 28 days
   var expiry = new Date();
-  expiry.setTime(expiry.getTime() + (3 * 24 * 60 * 60 * 1000));
+  expiry.setTime(expiry.getTime() + (28 * 24 * 60 * 60 * 1000));
   document.cookie = "stateFromUrl=" + stateString + "; expires=" + expiry.toGMTString();
 
   // Add link to switch to the evolution dashboard with the same settings


### PR DESCRIPTION
fixes : #366 
@chutten , I have made the requested changes. Is 28 days ok for you ?
One thing I would like to ask is that where do I find this line **'this is my current dashboard state'**. I tried searching but couldn't find. And one more question, when does this cookie come into action, as I couldn't login to any of the portals to see what happens there. 
  