### PR TITLE
Getting a lot of "none" urls from analytics.

### DIFF
--- a/analytics/analytics.js
+++ b/analytics/analytics.js
@@ -36,7 +36,7 @@ function decoratedLinkHandler(e) {
     return;
   }
   let anchor = findAnchor(e.target);
-  if (anchor && anchor.hostname != window.location.hostname) {
+  if (anchor && anchor.hostname && anchor.hostname != window.location.hostname) {
     gtag('event', 'outbound_link', {
       'event_category': 'user_interaction',
       'event_action': 'click',


### PR DESCRIPTION
I think we might be getting click events from things that aren't links.

That's unhelpful, so let's filter to register clicks on things that have
hostnames.