### PR TITLE
Ability to download entirety of keyed histogram

### DIFF
--- a/new-pipeline/src/dist.js
+++ b/new-pipeline/src/dist.js
@@ -1797,8 +1797,6 @@ function saveStateToUrlAndCookie() {
       // JSON
       var outputObj = {};
       gCurrentHistogramsList
-        .filter(titleHistogramsPair =>
-          shownKeys.indexOf(titleHistogramsPair.title) != -1)
         .sort((a, b) => shownKeys.indexOf(a.title) - shownKeys.indexOf(b.title))
         .forEach(titleHistogramsPair => {
           outputObj[titleHistogramsPair.title] = [];
@@ -1822,8 +1820,6 @@ function saveStateToUrlAndCookie() {
       histograms.forEach(hist => titles.push(hist.measure));
       outputArr.push(titles);
       gCurrentHistogramsList
-        .filter(titleHistogramsPair =>
-          shownKeys.indexOf(titleHistogramsPair.title) != -1)
         .sort((a, b) => shownKeys.indexOf(a.title) - shownKeys.indexOf(b.title))
         .forEach(titleHistogramsPair => {
           var record;


### PR DESCRIPTION
fixes : #259 

changes can be previewed here : https://himanish-star.github.io/telemetry-dashboard/

@chutten , I have attached the feature to download the histogram for all the keys. I have made two new buttons : `Export CSV Entire` and `Export JSON Entire`. But one problem I face is that these two buttons are not hidden in case of `non-keyed histograms`. I have used 
``` javascript 
$("#export-csv-entire").hide()
```
but it doesn't work