### PR TITLE
Low-hanging Performance Improvements for Evolution Dashboard

### DIFF
--- a/new-pipeline/evo.html
+++ b/new-pipeline/evo.html
@@ -11,7 +11,6 @@
     <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
     <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
     <link rel="stylesheet" href="style/bootstrap-multiselect.css" type="text/css"/>
-    <link rel="stylesheet" type="text/css" href="lib/daterangepicker-bs3.css" />
     <link rel="stylesheet" type="text/css" href="style/metricsgraphics.css" />
     
     <link rel="stylesheet" type="text/css" href="style/dashboards.css" />
@@ -115,7 +114,6 @@
     <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
     <script type="text/javascript" src="lib/bootstrap-multiselect.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/moment.js/2.10.2/moment.min.js"></script>
-    <script type="text/javascript" src="lib/daterangepicker.js"></script>
     
     <!-- MetricsGraphics libraries -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.5/d3.min.js" charset="utf-8"></script>

--- a/new-pipeline/src/dashboards.js
+++ b/new-pipeline/src/dashboards.js
@@ -108,23 +108,23 @@ $(document)
       });
 
     // Date range pickers
-    $(".date-range")
-      .daterangepicker();
-    $(
-        ".daterangepicker input[name=daterangepicker_start], .daterangepicker input[name=daterangepicker_end]"
-      )
-      .keydown(function (event) {
-        // Cause Enter to apply the settings
-        if (event.keyCode == 13) {
-          var $this = $(this)
-            .parents(".daterangepicker");
-          $this.find(".applyBtn")
-            .focus()
-            .click();
-          event.preventDefault();
-          return false;
-        }
-      });
+    if (document.getElementsByClassName("date-range").length) {
+      $(".date-range")
+        .daterangepicker();
+      $(".daterangepicker input[name=daterangepicker_start], .daterangepicker input[name=daterangepicker_end]")
+        .keydown(function (event) {
+          // Cause Enter to apply the settings
+          if (event.keyCode == 13) {
+            var $this = $(this)
+              .parents(".daterangepicker");
+            $this.find(".applyBtn")
+              .focus()
+              .click();
+            event.preventDefault();
+            return false;
+          }
+        });
+    }
 
     // Permalink control
     $(".permalink-control")


### PR DESCRIPTION
Found a couple of things while analysing usage patterns of tmo aggregates dashboards.

Shaving some hundreds of millis off of load should save a few pennies, but the big win is saving up to tens of seconds off switching metrics. (removing code while I'm at it)