### PR TITLE
Data Will Not Be Loaded Until User Is Done Picking Options

### DIFF
--- a/new-pipeline/src/dist.js
+++ b/new-pipeline/src/dist.js
@@ -9,11 +9,27 @@ var gPreviousFilterAllSelected = {};
 var gAxesList;
 var gAxesSelectors;
 var gNoneKey = "__none__";
+var gChangePending = false;
+const kDefaultFilterChangeTimeoutDelay = 3000;
 
 indicate("Initializing Telemetry...");
 
 $(function () {
   Telemetry.init(function () {
+    let btnGroup = $('.btn-group');
+    btnGroup.on('hide.bs.dropdown', function () {
+      if(gChangePending) {
+        setFilterChangeTimeout(function () {
+          $('#measure')
+            .trigger('change');
+        }, kDefaultFilterChangeTimeoutDelay);
+      }
+    });
+    btnGroup.on('click', function () {
+      if(gChangePending) {
+        clearTimeout(gFilterChangeTimeout);
+      }
+    });
     gFilters = {
       "application": $("#filter-product"),
       "os": $("#filter-os"),
@@ -143,10 +159,12 @@ $(function () {
 
       $("#channel-version")
         .change(function () {
-          updateOptions(function () {
-            $("#measure")
-              .trigger("change");
-          });
+          setFilterChangeTimeout(function () {
+            updateOptions(function () {
+              $("#measure")
+                .trigger("change");
+            });
+          }, kDefaultFilterChangeTimeoutDelay);
         });
       $([
         "input[name=build-time-toggle]",
@@ -164,7 +182,7 @@ $(function () {
           if (gFilterChangeTimeout !== null) {
             clearTimeout(gFilterChangeTimeout);
           }
-          gFilterChangeTimeout = setTimeout(function () { // Debounce the changes to prevent rapid filter changes from causing too many updates
+          setFilterChangeTimeout(function () { // Debounce the changes to prevent rapid filter changes from causing too many updates
             if (["filter-product", "filter-os"].indexOf($this
                 .attr("id")) >= 0) { // Only apply the select all change to the product and OS selector
               // If options (but not all options) were deselected when previously all options were selected, invert selection to include only those deselected
@@ -346,7 +364,7 @@ $(function () {
                   .trigger("change");
               }, $("input[name=sanitize-toggle]:checked")
               .val() !== "0");
-          }, 0);
+          }, e.target.id === 'measure' ? 0 : kDefaultFilterChangeTimeoutDelay);
         });
 
       $(
@@ -1884,4 +1902,12 @@ function saveStateToUrlAndCookie() {
 
 function isHistogramsListKeyed(histogramsList) {
   return histogramsList.some(entry => entry.title !== "");
+}
+
+function setFilterChangeTimeout(timeoutFunction, timeoutDelay) {
+  gChangePending = true;
+  gFilterChangeTimeout = setTimeout(() => {
+    timeoutFunction();
+    gChangePending = false;
+  }, timeoutDelay);
 }


### PR DESCRIPTION
fixes: #255
changes can be previewed at : https://himanish-star.github.io/telemetry-dashboard/

@chutten , I have added a delay of 0.8 s for all options except the `#measure` option in which there is no delay, as I believe all other options are only changed on the basis of the value of the `#measure` option. However I still don't think this is optimal as after 0.8 s the options will get updated and I don't think so it would actually solve the issue. What I intend on doing is to add an event listener for the `select` tags , and thus whenever a user is choosing options from the `select` options data shouldn't be loaded. What do you think? Although I think there are no event listeners to check for whether a user is still scrolling through the options as the only event listener for select is `change`. 