### PR TITLE
Render categorical histograms correctly.

### DIFF
--- a/wrapper/telemetry-wrapper.js
+++ b/wrapper/telemetry-wrapper.js
@@ -496,6 +496,9 @@ window.TelemetryWrapper.go = function (params, element) {
         if (!starts[index]) {
           return '';
         }
+        if (hist.kind == 'categorical') {
+          return starts[index];
+        }
         return formatNumber(starts[index]);
       },
       yax_format: value => value + '%',
@@ -511,6 +514,8 @@ window.TelemetryWrapper.go = function (params, element) {
           label = ' \u2265 ' + formatNumber(starts[index]);
         } else if (hist.kind == 'enumerated') {
           label = formatNumber(starts[index]);
+        } else if (hist.kind == 'categorical') {
+          label = starts[index];
         } else {
           label = '[' + formatNumber(starts[index])
                   + ', ' + formatNumber(ends[index]) + ')';
@@ -541,6 +546,29 @@ window.TelemetryWrapper.go = function (params, element) {
     var missingWidth = window.parseFloat(hangingBar.getAttribute('width'));
     for (var tick of graphEl.querySelectorAll('.mg-extended-y-ticks')) {
       tick.setAttribute('x2', window.parseFloat(tick.getAttribute('x2')) + missingWidth);
+    }
+
+    // The values used in this section are arbitrary, they seem to fit for now
+    if (hist.kind == 'categorical') {
+      // Rotate the x axis labels
+      for (var text of graphEl.querySelectorAll(".mg-x-axis text:not(.label)")) {
+        text.setAttribute("dx", "0.3em");
+        text.setAttribute("dy", "0");
+        text.setAttribute("text-anchor", "start");
+        text.setAttribute("transform", `rotate(20 ${text.getAttribute("x")} ${text.getAttribute("y")})`);
+        text.setAttribute("overflow", "visible");
+      }
+      // Increase the labels separator size
+      Array.from(graphEl.querySelectorAll(".mg-x-axis line"))
+        .map(l => l.setAttribute("y2", parseInt(l.getAttribute("y1")) + 12));
+      // Make sure the histogram label does not overlap the x axis labels
+      let histLabel = graphEl.querySelector(".mg-x-axis text.label");
+      histLabel.setAttribute("y", parseInt(histLabel.getAttribute("y")) + 30);
+      // Resize the graph containers
+      let svg = graphEl.querySelector("svg");
+      svg.setAttribute("height", parseInt(svg.getAttribute("height")) + 50);
+      let graphContainer = svg.parentNode.parentNode;
+      graphContainer.style.height = `${parseInt(graphContainer.clientHeight) + 50}px`;
     }
   }
 


### PR DESCRIPTION
Trying to figure out a -not too ugly- way to display the correct keys for #376. 

![screenshot from 2018-01-21 18-02-53](https://user-images.githubusercontent.com/9465678/35196747-726b1aee-fed6-11e7-9c50-b7c7201f99ab.png)

The keys seem to be correct, although it looks really bad ^^'. 
I don't really know what would be the most convenient layout (Maybe using acronyms instead ? A vertical display?) I have literally no taste so I would be more than happy to take any suggestions :)

I've added some really simple if statements in order to be able do show you a screenshot asap, but as stated by the telemetry documentation (https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/collection/histograms.html?highlight=categorical) there seem to be lots of allowed histogram kinds : 
``` 
boolean
linear
exponential
categorical
enumerated
flag
<deprecated> count 
``` 
I'm considering using switch / case statements to prepare the bucket labels (and maybe DRYing the code a little bit more), but I don't know the codebase enough to be able to judge if it would be useful / worth it.
@chutten @leplatrem What do you think ?
I would love to dig deeper on this if someone can mentor me :)

EDIT: After searching a bit more it seems like categorical is the only entry which wouldn't require any formatNumber() call, so I guess ifs are fine. 
As displayed here : https://telemetry.mozilla.org/histogram-simulator/#low=1&high=500&n_buckets=20&kind=exponential&generate=normal a vertical display seems the most used approach, so I'll update the PR and stay open for any suggestions :)