### PR TITLE
Fix #412 : Remove release warning message from dashboards

### DIFF
--- a/new-pipeline/dist.html
+++ b/new-pipeline/dist.html
@@ -29,10 +29,6 @@
                 <span class="permalink-control"></span>
             </form>
             <h1>Measurement Dashboard</h1>
-            <div class="error-msg">
-                The data from release users will go away soon, affecting this dashboard and the aggregates service.
-                For context, please read <a href="https://medium.com/@georg.fritzsche/data-preference-changes-in-firefox-58-2d5df9c428b5">this blog post</a>.
-            </div>
         </header>
         <div class="row">
             <div class="col-md-12">

--- a/new-pipeline/evo.html
+++ b/new-pipeline/evo.html
@@ -27,10 +27,6 @@
                 <span class="permalink-control"></span>
             </form>
             <h1>Evolution Dashboard</h1>
-            <div class="error-msg">
-                The data from release users will go away soon, affecting this dashboard and the aggregates service.
-                For context, please read <a href="https://medium.com/@georg.fritzsche/data-preference-changes-in-firefox-58-2d5df9c428b5">this blog post</a>.
-            </div>
         </header>
         <div class="row">
             <div class="col-md-12">


### PR DESCRIPTION
Warning messages are removed from the dashboard - both Measurement and Evolution Dashboard.
