### PR TITLE
Fix #383 : Limit the visible length of the probe descriptions

### DIFF
--- a/new-pipeline/dist.html
+++ b/new-pipeline/dist.html
@@ -62,7 +62,9 @@
                 </h2>
                 <hr></hr>
                 <figure class="col-md-12">
-                  <figcaption id="dist-caption"></figcaption>
+                  <figcaption id="dist-caption" class="caption-div"></figcaption>
+                  <figcaption id="caption-dots" class="caption-div"></figcaption>
+                  <figcaption id="dist-caption-link" class="caption-div"></figcaption>
                     <div class="col-md-9" id="plots">
                         <div class="row">
                             <div class="col-md-6" style="text-align: center">

--- a/new-pipeline/evo.html
+++ b/new-pipeline/evo.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+    <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="utf-8">
@@ -60,7 +60,9 @@
                     as
                     <select id="filter-process-type" class="multiselect" title="Process type" data-all-selected="any process type"></select>
                 </h2>
-                <h3 id="measure-description" style="font-size: 14px; margin: 0 3px"></h3>
+                <figcaption id="evo-caption" class="caption-div"></figcaption>
+                <figcaption id="caption-dots" class="caption-div"></figcaption>
+                 <figcaption id="evo-caption-link" class="caption-div"></figcaption> 
                 <h2 style="font-size: 18px; margin-bottom: 0">Showing graphs for <select id="selected-key" class="multiselect" title="Selected key"></select></h3>
                 <figure class="col-md-12">
                     <div class="col-md-12" id="evolutions"></div>

--- a/new-pipeline/src/dashboards.js
+++ b/new-pipeline/src/dashboards.js
@@ -1073,8 +1073,7 @@ function buildDictionaryURL(metric, channel, description) {
   return baseUrl + "?" + $.param(params);
 }
 
-function getDescriptionWithLink(metric, channel, description) {
-  var metricUrl = buildDictionaryURL(metric, channel, description);
+function getDescription(metric, channel, description) {
   var descr = metric;
   if (description && (description.length > 0)) {
     descr = description;
@@ -1084,6 +1083,16 @@ function getDescriptionWithLink(metric, channel, description) {
     class: "text-center",
   });
   div.append($("<span>").text(descr));
+
+  return div;
+}
+
+function getDescriptionLink(metric, channel, description) {
+  var metricUrl = buildDictionaryURL(metric, channel, description);
+
+  var div = $("<div>", {
+    class: "text-center",
+  });
 
   if (metricUrl) {
     var link = $("<a>", {

--- a/new-pipeline/src/dist.js
+++ b/new-pipeline/src/dist.js
@@ -886,9 +886,12 @@ function displayHistograms(histogramsList, dates, useTable, cumulative, trim) {
     var description = histogramsList[0].histograms[0].description
     var metric = histogramsList[0].histograms[0].measure
     var channel = $("#channel-version").val().split("/")[0]
-    var desc = getDescriptionWithLink(metric, channel, description)
+    var desc = getDescription(metric, channel, description)
+    var link = getDescriptionLink(metric, channel, description)
 
     $('#dist-caption').html(desc);
+    $('#caption-dots').html("...");
+    $('#dist-caption-link').html(link);
   } else {
     $('#dist-caption').text(""); // Clear the histogram caption
   }

--- a/new-pipeline/src/evo.js
+++ b/new-pipeline/src/evo.js
@@ -333,11 +333,13 @@ $(function () {
 
               var metric = $("#measure").val()
               var channel = $("#max-channel-version").val().split("/")[0]
-              var description = getDescriptionWithLink(metric, channel, evolutionDescription)
-
+              var description = getDescription(metric, channel, evolutionDescription)
+              var link = getDescriptionLink(metric, channel, description)
               $("#submissions-title").text(metric + " submissions");
               $("#sample-counts-title").text(metric + " sample counts");
-              $("#measure-description").html(description);
+              $("#evo-caption").html(description);
+              $('#caption-dots').html("...");
+              $('#evo-caption-link').html(link);
               $("#selected-key")
                 .trigger("change");
             });

--- a/new-pipeline/style/dashboards.css
+++ b/new-pipeline/style/dashboards.css
@@ -126,10 +126,26 @@
 .mg-marker-text { font-size: 12px !important; }
 .mg-markers line { stroke-width: 2px !important; }
 
-#dist-caption {
+.caption-div {
+  overflow-x: hidden; 
+  display: inline-block;  
+}
+
+#caption-dots {
+  width : 2%;
+  font-size: 1.5em;
+}
+
+#dist-caption, #evo-caption {
+  text-overflow: ellipsis;
+  white-space: nowrap;
   font-size: 1.5em;
   text-align: center;
-  margin: 0.1em;
+}
+
+#dist-caption-link, #evo-caption-link {
+  color : black;
+  font-size: 1.5em;
 }
 
 /* Error message styles */


### PR DESCRIPTION
If a probe has long caption, then it doesn't look good if shown completely in the UI. This PR has resolved this issue. Knowledge of HTML, CSS(especially styling `text-overflow: ellipsis;` ) and core JavaScript is required.  