### PR TITLE
Fixed issue-406: Use different styles for measure heading if description is available

### DIFF
--- a/new-pipeline/src/dashboards.js
+++ b/new-pipeline/src/dashboards.js
@@ -1073,16 +1073,17 @@ function buildDictionaryURL(metric, channel, description) {
 
 function getDescriptionWithLink(metric, channel, description) {
   var metricUrl = buildDictionaryURL(metric, channel, description);
-  var descr = metric;
+  var descr;
+
   if (description && (description.length > 0)) {
-    descr = description;
+  descr = description;
   }
 
   var div = $("<div>", {
     class: "text-center",
   });
+  div.append($("<h3>").text(metric));
   div.append($("<span>").text(descr));
-
   if (metricUrl) {
     var link = $("<a>", {
       href: metricUrl,

--- a/new-pipeline/src/dashboards.js
+++ b/new-pipeline/src/dashboards.js
@@ -1058,16 +1058,17 @@ function buildDictionaryURL(metric, channel, description) {
 
 function getDescriptionWithLink(metric, channel, description) {
   var metricUrl = buildDictionaryURL(metric, channel, description);
-  var descr = metric;
+  var descr;
+
   if (description && (description.length > 0)) {
-    descr = description;
+  descr = description;
   }
 
   var div = $("<div>", {
     class: "text-center",
   });
+  div.append($("<h3>").text(metric));
   div.append($("<span>").text(descr));
-
   if (metricUrl) {
     var link = $("<a>", {
       href: metricUrl,

--- a/new-pipeline/style/dashboards.css
+++ b/new-pipeline/style/dashboards.css
@@ -127,11 +127,15 @@
 .mg-markers line { stroke-width: 2px !important; }
 
 #dist-caption {
-  font-size: 1.5em;
   text-align: center;
   margin: 0.1em;
 }
-
+#dist-caption span {
+  font-size: 1em;
+  text-align: center;
+  margin: 0.1em;
+  font-weight: normal;
+}
 /* Error message styles */
 .error-msg {
   border: 2px solid #C13832; /* Mozilla Red */


### PR DESCRIPTION
Fixed issue-406- Use different styles for measure heading if description is available
Files that are changed in this PR-
1. dashboards.js
2. dashboards.css