### PR TITLE
Fix Issue #431: Remove unused class in main portal stylesheet

### DIFF
--- a/new-pipeline/style/dashboards.css
+++ b/new-pipeline/style/dashboards.css
@@ -16,11 +16,8 @@
   background: #326AA7;
   color: white;
 }
-.big-dashboard-list .dashboard-description { font-size: 18px; }
-.dashboard-list {
-  height: 600px;
-  overflow-y: auto;
-}
+.big-dashboard-list .list-group-item .dashboard-description { font-size: 18px; }
+
 .dashboard-list .list-group-item {
   border: none;
   border-top: 1px solid #ddd;

--- a/new-pipeline/style/dashboards.css
+++ b/new-pipeline/style/dashboards.css
@@ -17,15 +17,15 @@
   color: white;
 }
 .big-dashboard-list .list-group-item .dashboard-description { font-size: 18px; }
-.scrollable-dashboard-list {
+.dashboard-list {
   height: 600px;
   overflow-y: auto;
 }
-.scrollable-dashboard-list .list-group-item {
+.dashboard-list .list-group-item {
   border: none;
   border-top: 1px solid #ddd;
 }
-.scrollable-dashboard-list .list-group-item:first-child { border-top: none; }
+.dashboard-list .list-group-item:first-child { border-top: none; }
 
 /* Dropdown style overrides */
 .multiselect {

--- a/new-pipeline/style/dashboards.css
+++ b/new-pipeline/style/dashboards.css
@@ -16,7 +16,7 @@
   background: #326AA7;
   color: white;
 }
-.big-dashboard-list .list-group-item .dashboard-description { font-size: 18px; }
+.big-dashboard-list .dashboard-description { font-size: 18px; }
 .dashboard-list {
   height: 600px;
   overflow-y: auto;


### PR DESCRIPTION
This fixes #431 Replace unused .scrollable-dashboard-list style with just .dashboard-list

Previous `style/dashboard.css` for the main portal page has border styling that was removed by new `new-pipeline/style/dashboard.css` that should not have been removed. This PR includes those removed styles.

[Published Site](https://jquinnie.github.io/telemetry-dashboard/)

## **Before**
![telemetrybefore](https://user-images.githubusercontent.com/29465981/36986541-a9f5dfa8-205f-11e8-8e5b-3f987685d02f.PNG)

## **After**
![telemetryafter](https://user-images.githubusercontent.com/29465981/36986476-844c454e-205f-11e8-9136-8e614713f2ed.png)


_Let me know if the white space separate from `Main Tools` and `Documentation` was a desirable outcome, if not, I can update that style._
