### PR TITLE
Add icons for each section on landing page - Issue #426 

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -14,6 +15,7 @@
     <link rel="stylesheet" href="new-pipeline/style/dashboards.css">
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-49796218-2"></script>
 </head>
+
 <body>
     <div class="container-fluid">
         <header>
@@ -28,7 +30,7 @@
         </header>
         <div class="row">
             <div class="col-md-4">
-                <h3>Main tools</h3>
+                <h3><i class="fa fa-bar-chart colors-gradient"></i> Main tools</h3>
                 <div class="dashboard-list list-group" style="margin: 0">
                     <a class="list-group-item" href="new-pipeline/dist.html">
                         Measurement Dashboard
@@ -39,136 +41,166 @@
                         <div class="dashboard-description">See what hardware Firefox users have.</div>
                     </a>
                     <a class="list-group-item" href="https://sql.telemetry.mozilla.org/">
-                        SQL Portal <span class="fa fa-lock"></span>
+                        SQL Portal
+                        <span class="fa fa-lock"></span>
                         <div class="dashboard-description">View dashboards &amp; run SQL queries.</div>
                     </a>
                     <a class="list-group-item" href="https://moz-experiments-viewer.herokuapp.com/">
-                        Experiments Viewer <span class="fa fa-lock"></span>
+                        Experiments Viewer
+                        <span class="fa fa-lock"></span>
                         <div class="dashboard-description">See the impact different experiments have.</div>
                     </a>
                     <a class="list-group-item" href="https://data-missioncontrol.dev.mozaws.net/">
-                      Mission Control <div class="dashboard-description">View key Firefox quality measures in near-realtime.</div>
+                        Mission Control
+                        <div class="dashboard-description">View key Firefox quality measures in near-realtime.</div>
                     </a>
                     <a class="list-group-item" href="https://analysis.telemetry.mozilla.org/">
-                        Analysis Portal <span class="fa fa-lock"></span>
+                        Analysis Portal
+                        <span class="fa fa-lock"></span>
                         <div class="dashboard-description">Analyze telemetry data with Spark.</div>
                     </a>
                 </div>
-                <h3>Documentation</h3>
+                <h3><i class="fa fa-book colors-gradient"></i> Documentation</h3>
                 <div class="dashboard-list list-group" style="margin: 0">
                     <a class="list-group-item" href="https://docs.telemetry.mozilla.org/">
-                        Data Docs <div class="dashboard-description">Find what data is available &amp; how to use it.</div>
+                        Data Docs
+                        <div class="dashboard-description">Find what data is available &amp; how to use it.</div>
                     </a>
                     <a class="list-group-item" href="https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/">
-                        Firefox Telemetry Docs <div class="dashboard-description">Learn how to record data &amp; what data gets sent.</div>
+                        Firefox Telemetry Docs
+                        <div class="dashboard-description">Learn how to record data &amp; what data gets sent.</div>
                     </a>
                     <a class="list-group-item" href="https://georgf.github.io/fx-data-explorer/">
-                        Probe Dictionary <div class="dashboard-description">Find what probes are submitted from Firefox.</div>
+                        Probe Dictionary
+                        <div class="dashboard-description">Find what probes are submitted from Firefox.</div>
                     </a>
                     <a class="list-group-item" href="https://wiki.mozilla.org/Firefox/Shield">
-                        Shield Docs <div class="dashboard-description">Learn how to run Shield studies &amp; experiments.</div>
+                        Shield Docs
+                        <div class="dashboard-description">Learn how to run Shield studies &amp; experiments.</div>
                     </a>
                 </div>
             </div>
             <div class="col-md-4">
-                <h3>Getting help</h3>
+                <h3><i class="fa fa-question-circle colors-gradient"></i> Getting help</h3>
                 <div class="dashboard-list list-group">
                     <a class="list-group-item" href="https://mail.mozilla.org/listinfo/fx-data-dev">
-                      Join the mailing list
-                      <div class="dashboard-description">Get help on data topics and upcoming changes.</div>
+                        Join the mailing list
+                        <div class="dashboard-description">Get help on data topics and upcoming changes.</div>
                     </a>
                     <a class="list-group-item" href="https://bugzilla.mozilla.org/enter_bug.cgi?product=Data%20Platform%20and%20Tools&component=General">
-                      File a bug
-                      <div class="dashboard-description">File a bug with details on <i>bugzilla.mozilla.org</i>.</div>
+                        File a bug
+                        <div class="dashboard-description">File a bug with details on
+                            <i>bugzilla.mozilla.org</i>.</div>
                     </a>
                     <a class="list-group-item" href="https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23telemetry">
-                      Chat on IRC
-                      <div class="dashboard-description">Find us in <i>#telemetry</i> on <i>irc.mozilla.org</i>.</div>
+                        Chat on IRC
+                        <div class="dashboard-description">Find us in
+                            <i>#telemetry</i> on
+                            <i>irc.mozilla.org</i>.</div>
                     </a>
                     <a class="list-group-item" href="https://mozilla.slack.com/messages/C4D5ZA91B/">
-                      Join us on Slack <span class="fa fa-lock"></span>
-                      <div class="dashboard-description">Find us in <i>#fx-metrics</i> on Slack.</div>
+                        Join us on Slack
+                        <span class="fa fa-lock"></span>
+                        <div class="dashboard-description">Find us in
+                            <i>#fx-metrics</i> on Slack.</div>
                     </a>
                 </div>
-                <h3>Other tools</h3>
+                <h3><i class="fa fa-wrench colors-gradient"></i> Other tools</h3>
                 <div class="dashboard-list list-group">
                     <a class="list-group-item" href="https://reports.telemetry.mozilla.org/">
-                        Reports Portal <div class="dashboard-description">Explore data analyses &amp; reports.</div>
+                        Reports Portal
+                        <div class="dashboard-description">Explore data analyses &amp; reports.</div>
                     </a>
                     <a class="list-group-item" href="https://www.mozdatacollective.com/">
-                        Mozilla Data Collective <span class="fa fa-lock"></span>
+                        Mozilla Data Collective
+                        <span class="fa fa-lock"></span>
                         <div class="dashboard-description">View curated data reports from across Mozilla.</div>
                     </a>
                     <a class="list-group-item" href="https://sso.mozilla.com/amplitude">
-                        Amplitude <span class="fa fa-lock"></span>
+                        Amplitude
+                        <span class="fa fa-lock"></span>
                         <div class="dashboard-description">Dive into product analytics.</div>
                     </a>
                     <a class="list-group-item" href="dashboard-generator/index.html">
-                      Dashboard Generator
-                      <div class="dashboard-description">Hand-craft your own dashboard with the push of a few buttons</div>
+                        Dashboard Generator
+                        <div class="dashboard-description">Hand-craft your own dashboard with the push of a few buttons</div>
                     </a>
                     <a class="list-group-item" href="https://bsmedberg.github.io/telemetry-experiments-dashboard/">
-                        Experiment Monitoring <div class="dashboard-description">View vitals and statistics for Firefox Telemetry Experiments.</div>
+                        Experiment Monitoring
+                        <div class="dashboard-description">View vitals and statistics for Firefox Telemetry Experiments.</div>
                     </a>
                     <a class="list-group-item" href="http://alerts.telemetry.mozilla.org/">
-                        Telemetry Alerts <div class="dashboard-description">Set up email alerts for significant performance changes.</div>
+                        Telemetry Alerts
+                        <div class="dashboard-description">Set up email alerts for significant performance changes.</div>
                     </a>
                     <a class="list-group-item" href="https://people.mozilla.org/~danderson/moz-gfx-telemetry/www/">
-                        Graphics Telemetry <div class="dashboard-description">View percentage breakdowns for various graphics features.</div>
+                        Graphics Telemetry
+                        <div class="dashboard-description">View percentage breakdowns for various graphics features.</div>
                     </a>
                     <a class="list-group-item" href="https://georgf.github.io/usecounters/index.html">
-                        Use Counters <div class="dashboard-description">View usage of web features relative to page loads.</div>
+                        Use Counters
+                        <div class="dashboard-description">View usage of web features relative to page loads.</div>
                     </a>
                     <a class="list-group-item" href="update-orphaning/">
-                        Update Orphaning <div class="dashboard-description">View percentage breakdowns of users who are up-to-date vs. out-of-date.</div>
+                        Update Orphaning
+                        <div class="dashboard-description">View percentage breakdowns of users who are up-to-date vs. out-of-date.</div>
                     </a>
                     <a class="list-group-item" href="crashes/">
-                        Stability Dashboard <div class="dashboard-description">See how crash rates evolve over time</div>
+                        Stability Dashboard
+                        <div class="dashboard-description">See how crash rates evolve over time</div>
                     </a>
                     <a class="list-group-item" href="https://squarewave.github.io">
-                        Background Hang Reporting <div class="dashboard-description">View browser hang information collected from Nightly users</div>
+                        Background Hang Reporting
+                        <div class="dashboard-description">View browser hang information collected from Nightly users</div>
                     </a>
                     <a class="list-group-item" href="histogram-simulator/">
-                        Histogram Simulator <div class="dashboard-description">Simulate histogram bucket widths</div>
+                        Histogram Simulator
+                        <div class="dashboard-description">Simulate histogram bucket widths</div>
                     </a>
                 </div>
             </div>
             <div class="col-md-4">
-                <h3>What's new</h3>
+                <h3><i class="fa fa-newspaper-o colors-gradient"></i> What's new</h3>
                 <!-- Twitter widget -->
                 <div>
-                    <a class="twitter-timeline"
-                        href="https://twitter.com/MozTelemetry"
-                        data-tweet-limit="3"
-                        data-chrome="noheader nofooter noborders noscrollbar transparent"
+                    <a class="twitter-timeline" href="https://twitter.com/MozTelemetry" data-tweet-limit="3" data-chrome="noheader nofooter noborders noscrollbar transparent"
                         data-widget-id="410497663147053056">
                         Loading updates on telemetry...
-                    </a></br>
-                    <a href="https://twitter.com/MozTelemetry"
-                       class="twitter-follow-button"
-                       data-show-count="false"
-                       data-align="left"
-                       data-dnt="true"
-                       data-lang="en">
+                    </a>
+                    </br>
+                    <a href="https://twitter.com/MozTelemetry" class="twitter-follow-button" data-show-count="false" data-align="left" data-dnt="true"
+                        data-lang="en">
                         Follow @MozTelemetry
                     </a>
                 </div>
             </div>
         </div>
     </div>
-    <div><a href="https://www.mozilla.org/en-US/privacy/websites/">Mozilla's Website Privacy Notice</a></div>
+    <div>
+        <a href="https://www.mozilla.org/en-US/privacy/websites/">Mozilla's Website Privacy Notice</a>
+    </div>
 
     <!-- Bootstrap and supporting libraries -->
     <script src="https://code.jquery.com/jquery-1.11.3.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
 
     <script>
-    // Check for permalink - if there is a URL hash, the user probably clicked on a permalink to the old dashboard, so redirect them there with the same state to avoid breaking permalinks
-    if (window.location.hash.length > 1) {
-        window.location.href = window.location.origin + "/advanced/" + window.location.hash;
-    }
+        // Check for permalink - if there is a URL hash, the user probably clicked on a permalink to the old dashboard, so redirect them there with the same state to avoid breaking permalinks
+        if (window.location.hash.length > 1) {
+            window.location.href = window.location.origin + "/advanced/" + window.location.hash;
+        }
     </script>
     <script src="analytics/analytics.js"></script>
     <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+    <style>
+        .colors-gradient {
+            background-image: -webkit-linear-gradient(-45deg, rgba(230, 96, 0, 1) 0%, rgba(255, 149, 0, 1) 25%, rgba(0, 146, 219, 1) 75%, rgba(0, 82, 158, 1) 100%);
+            background-image: linear-gradient(135deg, rgba(230, 96, 0, 1) 0%, rgba(255, 149, 0, 1) 25%, rgba(0, 146, 219, 1) 75%, rgba(0, 82, 158, 1) 100%);
+            color: transparent;
+            -webkit-background-clip: text;
+            background-clip: text;
+        }
+    </style>
 </body>
+
 </html>


### PR DESCRIPTION
I added the font-awesome icons to the headings sections.
- The project use fontawesome of bootstrap in a version 4.3.0 and the link of the task proposes the icons to use are fontawesome version 5, so I am using the equivalents in the version that is being used.
- I proposed the newspaper icon 'fa fa-newspaper-o' for the What's new section, because I think it represents the news of a page
- I thought that to give Mozilla more visibility, it could use the colors of this one; so change the color of the icon (as a proposal) to a gradient with the colors that I found on this page https://www.mozilla.org/en-US/styleguide/identity/marketplace/color/

I attached an image with the modifications made. Please review it :)
![image](https://user-images.githubusercontent.com/14001107/36988382-bf4da662-206c-11e8-812c-be214a6acc21.png)
