### PR TITLE
Fix Issue #423: Add name to permalink generator, move to front of button row.

### DIFF
--- a/new-pipeline/dist.html
+++ b/new-pipeline/dist.html
@@ -21,7 +21,7 @@
 <body>
     <div class="container-fluid">
         <header>
-            <form class="navbar-form inline pull-right">
+            <form class="navbar-form inline pull-right btn-group">
                 <span class="permalink-control"></span>
                 <a href="https://github.com/mozilla/telemetry-dashboard/issues" class="btn btn-success" title="Report a bug in Telemetry dashboards" target="_blank">Report bug</a>
                 <a href="./evo.html" class="btn btn-default" id="switch-views" title="Switch to the evolution view">Evolution View</a>

--- a/new-pipeline/dist.html
+++ b/new-pipeline/dist.html
@@ -21,7 +21,7 @@
 <body>
     <div class="container-fluid">
         <header>
-            <form class="navbar-form inline pull-right btn-group">
+            <form class="navbar-form inline pull-right">
                 <span class="permalink-control"></span>
                 <a href="https://github.com/mozilla/telemetry-dashboard/issues" class="btn btn-success" title="Report a bug in Telemetry dashboards" target="_blank">Report bug</a>
                 <a href="./evo.html" class="btn btn-default" id="switch-views" title="Switch to the evolution view">Evolution View</a>

--- a/new-pipeline/dist.html
+++ b/new-pipeline/dist.html
@@ -21,7 +21,7 @@
 <body>
     <div class="container-fluid">
         <header>
-            <form class="navbar-form inline pull-right btn-row">
+            <form class="navbar-form inline pull-right btn-group">
                 <span class="permalink-control btn btn-default"></span>
                 <a href="https://github.com/mozilla/telemetry-dashboard/issues" class="btn btn-success" title="Report a bug in Telemetry dashboards" target="_blank">Report bug</a>
                 <a href="./evo.html" class="btn btn-default" id="switch-views" title="Switch to the evolution view">Evolution View</a>

--- a/new-pipeline/dist.html
+++ b/new-pipeline/dist.html
@@ -22,7 +22,7 @@
     <div class="container-fluid">
         <header>
             <form class="navbar-form inline pull-right btn-group">
-                <span class="permalink-control btn btn-default"></span>
+                <span class="permalink-control"></span>
                 <a href="https://github.com/mozilla/telemetry-dashboard/issues" class="btn btn-success" title="Report a bug in Telemetry dashboards" target="_blank">Report bug</a>
                 <a href="./evo.html" class="btn btn-default" id="switch-views" title="Switch to the evolution view">Evolution View</a>
                 <a href="/" class="btn btn-default btn-primary" title="Landing page for Telemetry dashboards">Dashboards Home</a>

--- a/new-pipeline/dist.html
+++ b/new-pipeline/dist.html
@@ -21,12 +21,12 @@
 <body>
     <div class="container-fluid">
         <header>
-            <form class="navbar-form inline pull-right">
+            <form class="navbar-form inline pull-right btn-row">
+                <span class="permalink-control btn btn-default"></span>
                 <a href="https://github.com/mozilla/telemetry-dashboard/issues" class="btn btn-success" title="Report a bug in Telemetry dashboards" target="_blank">Report bug</a>
                 <a href="./evo.html" class="btn btn-default" id="switch-views" title="Switch to the evolution view">Evolution View</a>
                 <a href="/" class="btn btn-default btn-primary" title="Landing page for Telemetry dashboards">Dashboards Home</a>
                 <a href="./tutorial.html#HistogramDashboard" class="btn btn-default" id="tutorial" title="Usage tutorial for Telemetry dashboards">Usage Tutorial</a>
-                <span class="permalink-control"></span>
             </form>
             <h1>Measurement Dashboard</h1>
         </header>

--- a/new-pipeline/evo.html
+++ b/new-pipeline/evo.html
@@ -19,7 +19,7 @@
 <body>
     <div class="container-fluid">
         <header>
-            <form class="navbar-form inline pull-right">
+            <form class="navbar-form inline pull-right btn-group">
                 <span class="permalink-control"></span>
                 <a href="https://github.com/mozilla/telemetry-dashboard/issues" class="btn btn-success" title="Report a bug in Telemetry dashboards" target="_blank">Report bug</a>
                 <a href="./dist.html" class="btn btn-default" id="switch-views" title="Switch to the distribution view">Distribution View</a>

--- a/new-pipeline/evo.html
+++ b/new-pipeline/evo.html
@@ -20,7 +20,7 @@
     <div class="container-fluid">
         <header>
             <form class="navbar-form inline pull-right btn-group">
-                <span class="permalink-control btn btn-default"></span>
+                <span class="permalink-control"></span>
                 <a href="https://github.com/mozilla/telemetry-dashboard/issues" class="btn btn-success" title="Report a bug in Telemetry dashboards" target="_blank">Report bug</a>
                 <a href="./dist.html" class="btn btn-default" id="switch-views" title="Switch to the distribution view">Distribution View</a>
                 <a href="/" class="btn btn-default btn-primary" title="Landing page for Telemetry dashboards">Dashboards Home</a>

--- a/new-pipeline/evo.html
+++ b/new-pipeline/evo.html
@@ -19,7 +19,7 @@
 <body>
     <div class="container-fluid">
         <header>
-            <form class="navbar-form inline pull-right">
+            <form class="navbar-form inline pull-right btn-group">
                 <span class="permalink-control btn btn-default"></span>
                 <a href="https://github.com/mozilla/telemetry-dashboard/issues" class="btn btn-success" title="Report a bug in Telemetry dashboards" target="_blank">Report bug</a>
                 <a href="./dist.html" class="btn btn-default" id="switch-views" title="Switch to the distribution view">Distribution View</a>

--- a/new-pipeline/evo.html
+++ b/new-pipeline/evo.html
@@ -19,7 +19,7 @@
 <body>
     <div class="container-fluid">
         <header>
-            <form class="navbar-form inline pull-right btn-group">
+            <form class="navbar-form inline pull-right">
                 <span class="permalink-control"></span>
                 <a href="https://github.com/mozilla/telemetry-dashboard/issues" class="btn btn-success" title="Report a bug in Telemetry dashboards" target="_blank">Report bug</a>
                 <a href="./dist.html" class="btn btn-default" id="switch-views" title="Switch to the distribution view">Distribution View</a>

--- a/new-pipeline/evo.html
+++ b/new-pipeline/evo.html
@@ -20,11 +20,11 @@
     <div class="container-fluid">
         <header>
             <form class="navbar-form inline pull-right">
+                <span class="permalink-control btn btn-default"></span>
                 <a href="https://github.com/mozilla/telemetry-dashboard/issues" class="btn btn-success" title="Report a bug in Telemetry dashboards" target="_blank">Report bug</a>
                 <a href="./dist.html" class="btn btn-default" id="switch-views" title="Switch to the distribution view">Distribution View</a>
                 <a href="/" class="btn btn-default btn-primary" title="Landing page for Telemetry dashboards">Dashboards Home</a>
                 <a href="./tutorial.html#EvolutionDashboard" class="btn btn-default" id="tutorial" title="Usage tutorial for Telemetry dashboards">Usage Tutorial</a>
-                <span class="permalink-control"></span>
             </form>
             <h1>Evolution Dashboard</h1>
         </header>

--- a/new-pipeline/src/dashboards.js
+++ b/new-pipeline/src/dashboards.js
@@ -130,7 +130,7 @@ $(document)
     $(".permalink-control")
       .append(
         '<div class="input-group">' +
-        '    <span class="input-group-btn"><button type="button" class="btn btn-default" title="Get Permalink"><span class="glyphicon glyphicon-link"></span></button></span>' +
+        '    <span class="input-group-btn"><button type="button" class="btn btn-default" title="Get Permalink">Get Permalink<span class="glyphicon glyphicon-link"></span></button></span>' +
         '    <input type="text" class="form-control">' +
         '</div>'
       );

--- a/new-pipeline/src/dashboards.js
+++ b/new-pipeline/src/dashboards.js
@@ -130,7 +130,7 @@ $(document)
     $(".permalink-control")
       .append(
         '<div class="input-group">' +
-        '    <span class="input-group-btn"><button type="button" class="btn btn-default" title="Get Permalink">Get Permalink<span class="glyphicon glyphicon-link"></span></button></span>' +
+        '    <span class="input-group-btn"><button type="button" class="btn btn-default" title="Get Permalink">Get Permalink</button></span>' +
         '    <input type="text" class="form-control">' +
         '</div>'
       );

--- a/new-pipeline/src/dashboards.js
+++ b/new-pipeline/src/dashboards.js
@@ -130,7 +130,7 @@ $(document)
     $(".permalink-control")
       .append(
         '<div class="input-group">' +
-        '    <span class="input-group-btn"><button type="button" class="btn btn-default" title="Get Permalink ">Get Permalink</button></span>' +
+        '    <span class="input-group-btn"><button type="button" class="btn btn-default" title="Get Permalink">Get Permalink</button></span>' +
         '    <input type="text" class="form-control">' +
         '</div>'
       );

--- a/new-pipeline/src/dashboards.js
+++ b/new-pipeline/src/dashboards.js
@@ -130,7 +130,7 @@ $(document)
     $(".permalink-control")
       .append(
         '<div class="input-group">' +
-        '    <span class="input-group-btn"><button type="button" class="btn btn-default" title="Get Permalink">Get Permalink</button></span>' +
+        '    <span class="input-group-btn"><button type="button" class="btn btn-default" title="Get Permalink ">Get Permalink</button></span>' +
         '    <input type="text" class="form-control">' +
         '</div>'
       );


### PR DESCRIPTION
Hi @georgf @chutten, here I've moved the permalink generator to the front of the button row, and added a name to it. Plus, the short-link generator still works!

Let me know what you think. Thank you!

You can view it live here: https://ecomerford.github.io/telemetry-dashboard/