### PR TITLE
Fix #443 : Add shortlink button to probe dictionary

### DIFF
--- a/probe-dictionary/explore.js
+++ b/probe-dictionary/explore.js
@@ -16,6 +16,48 @@ var gDatasetMappings = null;
 var gView = null;
 var gDetailViewId = null;
 
+$(document)
+  .ready(function () {  
+    // Permalink control
+    $(".permalink-control input")
+      .hide()
+      .focus(function () {
+        // Workaround for broken selection: http://stackoverflow.com/questions/5797539
+        var $this = $(this);
+        $this.select()
+          .mouseup(function () {
+            $this.unbind("mouseup");
+            return false;
+          });
+      });
+    $(".permalink-control button")
+      .click(function () {
+        var $this = $(this);
+        $.ajax({
+          url: "https://api-ssl.bitly.com/v3/shorten",
+          dataType: "json",
+          data: {
+            longUrl: window.location.href,
+            access_token: "48ecf90304d70f30729abe82dfea1dd8a11c4584",
+            format: "json"
+          },
+          success: function (response) {
+            var shortUrl = response.data.url;
+            if (shortUrl.indexOf(":") === 4) {
+              shortUrl = "https" + shortUrl.substring(4);
+            }
+            $this.parents(".permalink-control")
+              .find("input")
+              .show()
+              .val(shortUrl)
+              .focus();
+          },
+          async:false
+        });
+        document.execCommand('copy');
+      });
+  });
+
 function mark(marker) {
   if (performance.mark) {
     performance.mark(marker);

--- a/probe-dictionary/explorer.css
+++ b/probe-dictionary/explorer.css
@@ -8,6 +8,19 @@ body {
     margin-right: 2px;
 }
 
+.permalink-control button {
+    background: none;
+    cursor: pointer;
+    padding: 7.5px 8px;
+    line-height: 1.5;
+    color:rgba(255,255,255,.75);
+    font-family: "Segoe UI", "Source Sans Pro", Calibri, Candara, Arial, sans-serif;
+}
+
+.permalink-control button:hover {
+    color : white;
+}
+
 #github-banner img {
     position: absolute;
     top: 0;

--- a/probe-dictionary/index.html
+++ b/probe-dictionary/index.html
@@ -51,6 +51,14 @@
           <li>
             <a class="nav-link" href="https://telemetry.mozilla.org/"><i class="fa fa-home"></i> Telemetry portal</a>
           </li>
+          <li>
+            <div class="permalink-control">
+              <div class="input-group">
+                <span class="input-group-btn"><button type="button" class="btn btn-default" title="Get Permalink"><i class="fa fa-link"></i> Get Permalink</button></span>
+                <input type="text" class="form-control">
+              </div>
+            </div>
+          </li>
         </ul>
         <div class="navbar-text my-lg-0" id="last-updated">
           Updated <span id="last-updated-date"></span>


### PR DESCRIPTION
To make it easier to pass around links to specific searches in the probe dictionary, a button is added to get shortlinks. The button is added in the navbar with title "Get Permalink".
Two files are affected : `index.html` and `explore.js`