### PR TITLE
Fixes #446: Make probe dictionary header links more discoverable

### DIFF
--- a/probe-dictionary/explorer.css
+++ b/probe-dictionary/explorer.css
@@ -127,8 +127,3 @@ body {
     font-size: larger;
     padding-right: 8px;
 }
-
-.nav-item > a {
-    background-color: #5496cf;
-    border-radius: 4px;
-}

--- a/probe-dictionary/explorer.css
+++ b/probe-dictionary/explorer.css
@@ -124,6 +124,5 @@ body {
 }
 
 .nav-item {
-    font-size: larger;
-    padding-right: 8px;
+    font-weight: bold;
 }

--- a/probe-dictionary/explorer.css
+++ b/probe-dictionary/explorer.css
@@ -122,3 +122,13 @@ body {
 .hidden {
     display: none;
 }
+
+.nav-item {
+    font-size: larger;
+    padding-right: 8px;
+}
+
+.nav-item > a {
+    background-color: #5496cf;
+    border-radius: 4px;
+}

--- a/probe-dictionary/index.html
+++ b/probe-dictionary/index.html
@@ -31,11 +31,11 @@
       <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#navbarCollapse" aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>
-      <a class="navbar-brand" href="#">Probe dictionary</a>
+      <a class="navbar-brand" href="#">Probe Dictionary</a>
 
       <div class="collapse navbar-collapse" id="navbarCollapse">
         <ul class="navbar-nav mr-auto">
-          <li class="nav-item active">
+          <li class="nav-item">
             <a class="nav-link" data-toggle="tab" href="#search-results-view" role="tab" aria-controls="search-results-view">
               <i class="fa fa-search"></i> Find probes <span class="sr-only">(current)</span>
             </a>
@@ -48,7 +48,7 @@
           <li class="nav-item">
             <a class="nav-link" href="https://github.com/mozilla/probe-dictionary/issues/new" target="_blank"><i class="fa fa-bug"></i> File a bug</a>
           </li>
-          <li>
+          <li class="nav-item">
             <a class="nav-link" href="https://telemetry.mozilla.org/"><i class="fa fa-home"></i> Telemetry portal</a>
           </li>
         </ul>

--- a/probe-dictionary/index.html
+++ b/probe-dictionary/index.html
@@ -34,7 +34,7 @@
       <a class="navbar-brand" href="#">Probe Dictionary</a>
 
       <div class="collapse navbar-collapse" id="navbarCollapse">
-        <ul class="navbar-nav mr-auto navbar-custom">
+        <ul class="navbar-nav mr-auto">
           <li class="nav-item">
             <a class="nav-link" data-toggle="tab" href="#search-results-view" role="tab" aria-controls="search-results-view">
               <i class="fa fa-search"></i> Find probes <span class="sr-only">(current)</span>

--- a/probe-dictionary/index.html
+++ b/probe-dictionary/index.html
@@ -34,7 +34,7 @@
       <a class="navbar-brand" href="#">Probe Dictionary</a>
 
       <div class="collapse navbar-collapse" id="navbarCollapse">
-        <ul class="navbar-nav mr-auto">
+        <ul class="navbar-nav mr-auto navbar-custom">
           <li class="nav-item">
             <a class="nav-link" data-toggle="tab" href="#search-results-view" role="tab" aria-controls="search-results-view">
               <i class="fa fa-search"></i> Find probes <span class="sr-only">(current)</span>


### PR DESCRIPTION
Fixes #446  

From recently added 'Probe Dictionary' page...
Header links were hard to find on the main index page, CSS styling updates to make the font size larger and add a box overlay to each link, see _Before_ and _After_ below;

**_Before_**
![telemetry1before](https://user-images.githubusercontent.com/29465981/37113875-4a239b7a-220c-11e8-94eb-5d5934b7dbba.PNG)

**_After_**
![telemetry1after](https://user-images.githubusercontent.com/29465981/37113886-51b75430-220c-11e8-8d2a-1e2cf1c077bd.PNG)

Let me know if you would like any additional adders.
[Live site for reference](https://jquinnie.github.io/telemetry-dashboard/probe-dictionary)
