### PR TITLE
Fix #440: Add button group to dashboard buttons.

### DIFF
--- a/new-pipeline/dist.html
+++ b/new-pipeline/dist.html
@@ -22,8 +22,9 @@
     <div class="container-fluid">
         <header>
             <form class="navbar-form inline pull-right">
-                <span class="permalink-control"></span>
                 <div class="btn-group">
+                <a href="#" class="btn btn-default">Get permalink</a>
+                <input type="text" class="input btn btn-default"></span>
                 <a href="https://github.com/mozilla/telemetry-dashboard/issues" class="btn btn-success" title="Report a bug in Telemetry dashboards" target="_blank">Report bug</a>
                 <a href="./evo.html" class="btn btn-default" id="switch-views" title="Switch to the evolution view">Evolution View</a>
                 <a href="/" class="btn btn-default btn-primary" title="Landing page for Telemetry dashboards">Dashboards Home</a>

--- a/new-pipeline/dist.html
+++ b/new-pipeline/dist.html
@@ -23,8 +23,8 @@
         <header>
             <form class="navbar-form inline pull-right">
                 <div class="btn-group">
-                <a href="#" class="btn btn-default">Get permalink</a>
-                <input type="text" class="input btn btn-default"></span>
+                <span class="permalink-control"><a href="#" class="btn btn-default">Get permalink</a>
+                <input type="text" class="input btn btn-default form-control"></span>
                 <a href="https://github.com/mozilla/telemetry-dashboard/issues" class="btn btn-success" title="Report a bug in Telemetry dashboards" target="_blank">Report bug</a>
                 <a href="./evo.html" class="btn btn-default" id="switch-views" title="Switch to the evolution view">Evolution View</a>
                 <a href="/" class="btn btn-default btn-primary" title="Landing page for Telemetry dashboards">Dashboards Home</a>

--- a/new-pipeline/dist.html
+++ b/new-pipeline/dist.html
@@ -22,12 +22,14 @@
     <div class="container-fluid">
         <header>
             <form class="navbar-form inline pull-right">
+                <div class="btn-group">
                 <span class="permalink-control"></span>
                 <a href="https://github.com/mozilla/telemetry-dashboard/issues" class="btn btn-success" title="Report a bug in Telemetry dashboards" target="_blank">Report bug</a>
                 <a href="./evo.html" class="btn btn-default" id="switch-views" title="Switch to the evolution view">Evolution View</a>
                 <a href="/" class="btn btn-default btn-primary" title="Landing page for Telemetry dashboards">Dashboards Home</a>
                 <a href="./tutorial.html#HistogramDashboard" class="btn btn-default" id="tutorial" title="Usage tutorial for Telemetry dashboards">Usage Tutorial</a>
-            </form>
+                </div>
+             </form>
             <h1>Measurement Dashboard</h1>
         </header>
         <div class="row">

--- a/new-pipeline/dist.html
+++ b/new-pipeline/dist.html
@@ -22,8 +22,8 @@
     <div class="container-fluid">
         <header>
             <form class="navbar-form inline pull-right">
-                <div class="btn-group">
                 <span class="permalink-control"></span>
+                <div class="btn-group">
                 <a href="https://github.com/mozilla/telemetry-dashboard/issues" class="btn btn-success" title="Report a bug in Telemetry dashboards" target="_blank">Report bug</a>
                 <a href="./evo.html" class="btn btn-default" id="switch-views" title="Switch to the evolution view">Evolution View</a>
                 <a href="/" class="btn btn-default btn-primary" title="Landing page for Telemetry dashboards">Dashboards Home</a>

--- a/new-pipeline/evo.html
+++ b/new-pipeline/evo.html
@@ -21,7 +21,7 @@
         <header>
             <form class="navbar-form inline pull-right">
                 <div class="btn-group">
-                <a href="#" class="btn btn-default">Get permalink</a>
+                <span class="permalink-control"><a href="#" class="btn btn-default">Get permalink</a>
                 <input type="text" class="input btn btn-default"></span>
                 <a href="https://github.com/mozilla/telemetry-dashboard/issues" class="btn btn-success" title="Report a bug in Telemetry dashboards" target="_blank">Report bug</a>
                 <a href="./dist.html" class="btn btn-default" id="switch-views" title="Switch to the distribution view">Distribution View</a>

--- a/new-pipeline/evo.html
+++ b/new-pipeline/evo.html
@@ -20,8 +20,9 @@
     <div class="container-fluid">
         <header>
             <form class="navbar-form inline pull-right">
-                <span class="permalink-control"></span>
-                <div class="btn-group"
+                <div class="btn-group">
+                <a href="#" class="btn btn-default">Get permalink</a>
+                <input type="text" class="input btn btn-default"></span>
                 <a href="https://github.com/mozilla/telemetry-dashboard/issues" class="btn btn-success" title="Report a bug in Telemetry dashboards" target="_blank">Report bug</a>
                 <a href="./dist.html" class="btn btn-default" id="switch-views" title="Switch to the distribution view">Distribution View</a>
                 <a href="/" class="btn btn-default btn-primary" title="Landing page for Telemetry dashboards">Dashboards Home</a>

--- a/new-pipeline/evo.html
+++ b/new-pipeline/evo.html
@@ -20,11 +20,13 @@
     <div class="container-fluid">
         <header>
             <form class="navbar-form inline pull-right">
+                <div class="btn-group"
                 <span class="permalink-control"></span>
                 <a href="https://github.com/mozilla/telemetry-dashboard/issues" class="btn btn-success" title="Report a bug in Telemetry dashboards" target="_blank">Report bug</a>
                 <a href="./dist.html" class="btn btn-default" id="switch-views" title="Switch to the distribution view">Distribution View</a>
                 <a href="/" class="btn btn-default btn-primary" title="Landing page for Telemetry dashboards">Dashboards Home</a>
                 <a href="./tutorial.html#EvolutionDashboard" class="btn btn-default" id="tutorial" title="Usage tutorial for Telemetry dashboards">Usage Tutorial</a>
+            </div>
             </form>
             <h1>Evolution Dashboard</h1>
         </header>

--- a/new-pipeline/evo.html
+++ b/new-pipeline/evo.html
@@ -20,8 +20,8 @@
     <div class="container-fluid">
         <header>
             <form class="navbar-form inline pull-right">
-                <div class="btn-group"
                 <span class="permalink-control"></span>
+                <div class="btn-group"
                 <a href="https://github.com/mozilla/telemetry-dashboard/issues" class="btn btn-success" title="Report a bug in Telemetry dashboards" target="_blank">Report bug</a>
                 <a href="./dist.html" class="btn btn-default" id="switch-views" title="Switch to the distribution view">Distribution View</a>
                 <a href="/" class="btn btn-default btn-primary" title="Landing page for Telemetry dashboards">Dashboards Home</a>

--- a/new-pipeline/src/dashboards.js
+++ b/new-pipeline/src/dashboards.js
@@ -127,6 +127,13 @@ $(document)
     }
 
     // Permalink control
+   $(".permalink-control")
+      .append(
+        '<div class="input-group">' +
+        '    <span class="input-group-btn"><button title="Get Permalink"><i class="fa fa-link"></i></button></span>' +
+        '    <input type="text" class="form-control">' +
+        '</div>'
+      );
     $(".permalink-control input")
       .hide()
       .focus(function () {

--- a/new-pipeline/src/dashboards.js
+++ b/new-pipeline/src/dashboards.js
@@ -127,13 +127,6 @@ $(document)
     }
 
     // Permalink control
-    $(".permalink-control")
-      .append(
-        '<div class="input-group">' +
-        '    <span class="input-group-btn"><button type="button" class="btn btn-default" title="Get Permalink">Get Permalink</button></span>' +
-        '    <input type="text" class="form-control">' +
-        '</div>'
-      );
     $(".permalink-control input")
       .hide()
       .focus(function () {


### PR DESCRIPTION
Hi @georgf, could you review this when you get a chance?

The page is live [here](https://ecomerford.github.io/telemetry-dashboard/). 

I tried to have the permalink button be included in the button group, but it was relegated to the end of the row when I did that. I think because it expands? So I thought better to have it in front as we discussed and remove it from the button group. That's what I've done here. If you have any ideas on keeping it in the front of the row _and_ in the button group, I'm happy to look into it again!

Thank you!
