### PR TITLE
Fix #455 : The dashboard should link to probe-dictionary, not fx-data…

### DIFF
--- a/new-pipeline/src/dashboards.js
+++ b/new-pipeline/src/dashboards.js
@@ -1031,7 +1031,7 @@ function updateOSs() {
 
 // Build a URL for linking to the probe-dictionary.
 function buildDictionaryURL(metric, channel, description) {
-  var baseUrl = "https://georgf.github.io/fx-data-explorer/index.html";
+  var baseUrl = "https://telemetry.mozilla.org/probe-dictionary/";
   var params = {
     "searchtype": "in_name",
     "optout": "false",


### PR DESCRIPTION
Probe "More Details" link redirected to `telemetry.mozilla.org/probe-dictionary`.