### PR TITLE
Fix #459 : Stats tab doesn't display if channel is set to any

### DIFF
--- a/probe-dictionary/explore.js
+++ b/probe-dictionary/explore.js
@@ -185,8 +185,8 @@ function showSearchOnlyFilters(show) {
     }
 
     var channel = $("#select_channel").val();
-    if (!["release", "beta", "nightly", "any"].includes(channel)) {
-      $("#select_channel").val("any");
+    if (!["release", "beta", "nightly"].includes(channel)) {
+      $("#select_channel").val("release");
     }
   }
 }


### PR DESCRIPTION
If the channel is set to "any", the stats tab won't load properly due and will log
TypeError: data[0] is undefined
Redirecting the channel to proper page fixes the issue.