### PR TITLE
Fix #458 : Only show URL params that have non-default values

### DIFF
--- a/probe-dictionary/explore.js
+++ b/probe-dictionary/explore.js
@@ -593,10 +593,37 @@ function updateSearchParams(pushState = false) {
     params.detailView = gDetailViewId;
   }
 
+  if (params['search']=="") {
+    delete params.search;
+  }
+  if (params['searchtype']=="in_any") {
+    delete params.searchtype;
+  }
+  if (params['optout']==false) {
+    delete params.optout;
+  }
+  if (params['channel']=="any") {
+    delete params.channel;
+  }
+  if (params['constraint']=="is_in") {
+    delete params.constraint;
+  }
+  if (params['version']=="any") {
+    delete params.version;
+  }
+  if (params['view']=="search-results-view") {
+    delete params.view;
+  }
+
+  let queryString = "";
+  if (Object.keys(params).length) {
+    queryString = "?" + $.param(params);
+  }
+  
   if (!pushState) {
-    window.history.replaceState("", "", "?" + $.param(params));
+    window.history.replaceState({}, "", queryString);
   } else {
-    window.history.pushState("", "", "?" + $.param(params));
+    window.history.pushState({}, "", queryString);
   }
 }
 


### PR DESCRIPTION
We store a lot of values in the URL params. We could greatly shorten the links if we only use params for non-default values. Knowledge of work-flow of code-base and JavaScript resolved the issue. 
`explore.js` is affected. 

@chutten @georgf , Please review. Thanks! 
Here is the live link : [https://sylvia23.github.io/telemetry-dashboard/probe-dictionary/](url)