### PR TITLE
Fix #406 : Use different styles for measure heading if description is available

### DIFF
--- a/new-pipeline/src/dist.js
+++ b/new-pipeline/src/dist.js
@@ -876,7 +876,11 @@ function displayHistograms(histogramsList, dates, useTable, cumulative, trim) {
     var channel = $("#channel-version").val().split("/")[0]
     var desc = getDescription(metric, channel, description);
     var link = getDescriptionLink(metric, channel, description);
-    $('#dist-caption-text').html(desc);
+    if (metric != desc) {
+      $('#dist-caption-text').html(desc);
+    } else {
+      $('#dist-caption-text').text("");
+    }
     $('#dist-caption-link').html(link);
   } else {
     $('#dist-caption-text').text(""); // Clear the histogram caption

--- a/new-pipeline/src/evo.js
+++ b/new-pipeline/src/evo.js
@@ -328,7 +328,11 @@ $(function () {
               var link = getDescriptionLink(metric, channel, description);
               $("#submissions-title").text(metric + " submissions");
               $("#sample-counts-title").text(metric + " sample counts");
-              $("#evo-caption-text").html(description);
+              if (metric != description) {
+                $("#evo-caption-text").html(description);
+              } else {
+                $('#evo-caption-text').text("");
+              }
               $('#evo-caption-link').html(link);
               $("#selected-key")
                 .trigger("change");


### PR DESCRIPTION
Since it is a follow up issue of #418 , it can be easily solved by adding one `if-else` statement each in `dist.js` and `evo.js` files and rendering the value of headings with variable name `metric` and `description` from `dist.js` and `evo.js` respectively.
It also resolves the merge conflicts in #427 
@chutten @georgf , Please have a look. Thanks!
I will make it live after #500 if required.