### PR TITLE
Fix #404 : First Click on the aggregates selector on Evolution dashboard sometimes does not select anything

### DIFF
--- a/new-pipeline/src/evo.js
+++ b/new-pipeline/src/evo.js
@@ -406,7 +406,7 @@ function updateAggregates(kind, buckets) {
   }
 
   // Load aggregates from state on first load
-  newAggregates = newAggregates.map(entry => entry[0]);
+  newAggregates = newAggregates.map(entry => entry[1]);
   let aggregates = gInitialPageState.aggregates.filter(aggregate => newAggregates.includes(aggregate));
   if (!gLoadedAggregatesFromState && aggregates.length > 0) {
     gLoadedAggregatesFromState = true;


### PR DESCRIPTION
First Click on the aggregates selector on Evolution dashboard sometimes does not select anything and get discarded. Knowledge of workflow of the function `updateAggregates` along with hit and trial worked here while solving the issue.
One file `evo.js` is affected. 
@o0Ignition0o @chutten , Please review. Thanks!