### PR TITLE
Fix #506 : Rename Get permalink to Get shortlink in probe-dictionary

### DIFF
--- a/probe-dictionary/index.html
+++ b/probe-dictionary/index.html
@@ -54,7 +54,7 @@
           <li>
             <div class="permalink-control">
               <div class="input-group">
-                <span class="input-group-btn"><button type="button" class="btn btn-default" title="Get Permalink"><i class="fa fa-link"></i> Get Permalink</button></span>
+                <span class="input-group-btn"><button type="button" class="btn btn-default" title="Get Shortlink"><i class="fa fa-link"></i> Get Shortlink</button></span>
                 <input type="text" class="form-control">
               </div>
             </div>


### PR DESCRIPTION
It's a follow up issue of issue [#443](https://github.com/mozilla/telemetry-dashboard/pull/450/files) In the probe-dictionary, the "Get permalink" button actually gives users a "shortlink".
We should rename it accordingly to a get clearer view. One file `index.html` is affected.