### PR TITLE
Fix #505: The "permalink" button in probe-dictionary should be bold

### DIFF
--- a/probe-dictionary/explorer.css
+++ b/probe-dictionary/explorer.css
@@ -14,6 +14,7 @@ body {
     padding: 7.5px 8px;
     line-height: 1.5;
     color:rgba(255,255,255,.75);
+    font-weight: 700;
     font-family: "Segoe UI", "Source Sans Pro", Calibri, Candara, Arial, sans-serif;
 }
 

--- a/probe-dictionary/explorer.css
+++ b/probe-dictionary/explorer.css
@@ -8,13 +8,17 @@ body {
     margin-right: 2px;
 }
 
+.navbar-brand {
+    font-weight: bold;
+}
+
 .permalink-control button {
     background: none;
     cursor: pointer;
     padding: 7.5px 8px;
     line-height: 1.5;
     color:rgba(255,255,255,.75);
-    font-weight: 700;
+    font-weight: bold;
     font-family: "Segoe UI", "Source Sans Pro", Calibri, Candara, Arial, sans-serif;
 }
 


### PR DESCRIPTION
To match with the style of other buttons, permalink button should be bold too.


