### PR TITLE
Fix #507 :  Rename Get Permalink to Get shortlink in measurements dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ A local webserver is really helpful for running a version of the site on the sam
           npm install http-server -g
           # now visit localhost:8080 in your browser to see the page
 
-Permalink buttons (in the top right hand corner of the main dashboards) will not work when running the site on local servers. This is because they are shortened with bit.ly, which doesn't allow local links.
+Shortlink buttons (in the top right hand corner of the main dashboards) will not work when running the site on local servers. This is because they are shortened with bit.ly, which doesn't allow local links.
 
 ### Submitting pull requests for the dashboard
 

--- a/new-pipeline/dist.html
+++ b/new-pipeline/dist.html
@@ -22,7 +22,7 @@
     <div class="container-fluid">
         <header>
             <form class="navbar-form inline pull-right btn-group">
-                <a href="#" class="btn btn-default permalink-button" title="Get Permalink"><i class="fa fa-link"></i> Get Permalink</a>
+                <a href="#" class="btn btn-default permalink-button" title="Get Shortlink"><i class="fa fa-link"></i> Get Shortlink</a>
                 <input type="text" class="permalink-text input btn btn-default">
                 <a href="https://github.com/mozilla/telemetry-dashboard/issues" class="btn btn-success" title="Report a bug in Telemetry dashboards" target="_blank"><i class="fa fa-bug"></i> Report bug</a>
                 <a href="/" class="btn btn-default btn-primary" title="Landing page for Telemetry dashboards"><i class="fa fa-home"></i> Telemetry Portal</a>

--- a/new-pipeline/evo.html
+++ b/new-pipeline/evo.html
@@ -20,7 +20,7 @@
     <div class="container-fluid">
         <header>
             <form class="navbar-form inline pull-right btn-group">
-                <a href="#" class="btn btn-default permalink-button" title="Get Permalink"><i class="fa fa-link"></i> Get Permalink</a>
+                <a href="#" class="btn btn-default permalink-button" title="Get Shortlink"><i class="fa fa-link"></i> Get Shortlink</a>
                 <input type="text" class="permalink-text input btn btn-default">
                 <a href="https://github.com/mozilla/telemetry-dashboard/issues" class="btn btn-success" title="Report a bug in Telemetry dashboards" target="_blank"><i class="fa fa-bug"></i> Report bug</a>
                 <a href="/" class="btn btn-default btn-primary" title="Landing page for Telemetry dashboards"><i class="fa fa-home"></i> Telemetry Portal</a>


### PR DESCRIPTION
In the measurements dashboard, the "Get permalink" button actually gets us a "shortlink". We should rename it to `Get Shortlink` to avoid misunderstandings.
Three files have been affected `dist.html`, `evo.html` and `README.md` for better user experience and documentation.
@georgf Please review. Thanks!