### PR TITLE
Fix #514: Show only one TMO dashboard link in probe-dictionary

### DIFF
--- a/probe-dictionary/explore.js
+++ b/probe-dictionary/explore.js
@@ -679,9 +679,7 @@ function getDatasetInfos(probeId, channel, state) {
       (probe.type == "simpleMeasurements" && ["number", "bool"].includes(state.details.kind))) {
     var versions = getVersionRange(channel, state.revisions);
     const distURL = getTelemetryDashboardURL('dist', probe.name, probe.type, channel, versions.first, versions.last);
-    const evoURL = getTelemetryDashboardURL('evo', probe.name, probe.type, channel, versions.first, versions.last);
-    datasetInfos.push("TMO dashboard: "
-                      + `<a href="${distURL}" target="_blank">Measurements dashboard</a>`);
+    datasetInfos.push(`<a href="${distURL}" target="_blank">Measurements dashboard</a>`);
   }
 
   // Use counter dashboard links.

--- a/probe-dictionary/explore.js
+++ b/probe-dictionary/explore.js
@@ -681,9 +681,7 @@ function getDatasetInfos(probeId, channel, state) {
     const distURL = getTelemetryDashboardURL('dist', probe.name, probe.type, channel, versions.first, versions.last);
     const evoURL = getTelemetryDashboardURL('evo', probe.name, probe.type, channel, versions.first, versions.last);
     datasetInfos.push("TMO dashboard: "
-                      + `<a href="${distURL}" target="_blank">distribution</a>`
-                      + ", "
-                      + `<a href="${evoURL}" target="_blank">evolution</a>`);
+                      + `<a href="${distURL}" target="_blank">Measurements dashboard</a>`);
   }
 
   // Use counter dashboard links.


### PR DESCRIPTION
A single link to measurements dashboard.
Link: https://insiyaa.github.io/telemetry-dashboard/probe-dictionary/