### PR TITLE
Issue #474: Link to use counter dashboard for selections that include "USE_COUNTER2"

### DIFF
--- a/new-pipeline/dist.html
+++ b/new-pipeline/dist.html
@@ -57,6 +57,9 @@
                         <option value="child">process type</option>
                     </select>
                 </h2>
+                <h4 class="use-counter-link">
+                  <a href="#">View in use counter dashboard.</a>
+                </h4>
                 <hr></hr>
                 <figure class="col-md-12">
                     <div class="caption-div">

--- a/new-pipeline/evo.html
+++ b/new-pipeline/evo.html
@@ -4,12 +4,15 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    
     <title>Evolution Dashboard</title>
+    
     <!-- Bootstrap and supporting libraries -->
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
     <link rel="stylesheet" href="style/bootstrap-multiselect.css" type="text/css"/>
     <link rel="stylesheet" type="text/css" href="style/metricsgraphics.css" />
+    
     <link rel="stylesheet" type="text/css" href="style/dashboards.css" />
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-49796218-2"></script>
 </head>
@@ -110,17 +113,21 @@
         <span class="busy-indicator-message">Loading page...</span>
     </div>
     <div><a href="https://www.mozilla.org/en-US/privacy/websites/">Mozilla's Website Privacy Notice</a></div>
+    
     <!-- Bootstrap and supporting libraries -->
     <script src="https://code.jquery.com/jquery-1.11.3.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
     <script type="text/javascript" src="lib/bootstrap-multiselect.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.10.2/moment.min.js"></script>
+    
     <!-- MetricsGraphics libraries -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.5/d3.min.js" charset="utf-8"></script>
     <script src="lib/metricsgraphics.min.js"></script>
+ 
     <script src="../v2/telemetry.js"></script>
     <script src="src/dashboards.js"></script>
     <script src="src/evo.js"></script>
+    
     <script src="../analytics/analytics.js"></script>
 </body>
 </html>

--- a/new-pipeline/evo.html
+++ b/new-pipeline/evo.html
@@ -4,15 +4,12 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-
     <title>Evolution Dashboard</title>
-
     <!-- Bootstrap and supporting libraries -->
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
     <link rel="stylesheet" href="style/bootstrap-multiselect.css" type="text/css"/>
     <link rel="stylesheet" type="text/css" href="style/metricsgraphics.css" />
-
     <link rel="stylesheet" type="text/css" href="style/dashboards.css" />
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-49796218-2"></script>
 </head>
@@ -113,21 +110,17 @@
         <span class="busy-indicator-message">Loading page...</span>
     </div>
     <div><a href="https://www.mozilla.org/en-US/privacy/websites/">Mozilla's Website Privacy Notice</a></div>
-
     <!-- Bootstrap and supporting libraries -->
     <script src="https://code.jquery.com/jquery-1.11.3.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
     <script type="text/javascript" src="lib/bootstrap-multiselect.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.10.2/moment.min.js"></script>
-
     <!-- MetricsGraphics libraries -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.5/d3.min.js" charset="utf-8"></script>
     <script src="lib/metricsgraphics.min.js"></script>
-
     <script src="../v2/telemetry.js"></script>
     <script src="src/dashboards.js"></script>
     <script src="src/evo.js"></script>
-
     <script src="../analytics/analytics.js"></script>
 </body>
 </html>

--- a/new-pipeline/evo.html
+++ b/new-pipeline/evo.html
@@ -4,15 +4,15 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    
+
     <title>Evolution Dashboard</title>
-    
+
     <!-- Bootstrap and supporting libraries -->
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
     <link rel="stylesheet" href="style/bootstrap-multiselect.css" type="text/css"/>
     <link rel="stylesheet" type="text/css" href="style/metricsgraphics.css" />
-    
+
     <link rel="stylesheet" type="text/css" href="style/dashboards.css" />
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-49796218-2"></script>
 </head>
@@ -58,13 +58,16 @@
                     as
                     <select id="filter-process-type" class="multiselect" title="Process type" data-all-selected="any process type"></select>
                 </h2>
+                <h4 class="use-counter-link">
+                  <a href="#">View in use counter dashboard.</a>
+                </h4>
                 <hr></hr>
                 <div class="caption-div">
                     <figcaption id="evo-caption-text" class="overflow"></figcaption>
                     <figcaption id="evo-caption-link"></figcaption>
-                </div> 
-                
-                <h2 style="font-size: 18px; margin-bottom: 0">Showing graphs for key <select id="selected-key" class="multiselect" title="Selected key"></select></h2>          
+                </div>
+
+                <h2 style="font-size: 18px; margin-bottom: 0">Showing graphs for key <select id="selected-key" class="multiselect" title="Selected key"></select></h2>
                 <figure class="col-md-12">
                     <div class="col-md-12" id="evolutions"></div>
                 </figure>
@@ -110,13 +113,13 @@
         <span class="busy-indicator-message">Loading page...</span>
     </div>
     <div><a href="https://www.mozilla.org/en-US/privacy/websites/">Mozilla's Website Privacy Notice</a></div>
-    
+
     <!-- Bootstrap and supporting libraries -->
     <script src="https://code.jquery.com/jquery-1.11.3.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
     <script type="text/javascript" src="lib/bootstrap-multiselect.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.10.2/moment.min.js"></script>
-    
+
     <!-- MetricsGraphics libraries -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.5/d3.min.js" charset="utf-8"></script>
     <script src="lib/metricsgraphics.min.js"></script>

--- a/new-pipeline/src/dashboards.js
+++ b/new-pipeline/src/dashboards.js
@@ -701,7 +701,7 @@ function getHumanReadableOptions(filterName, options) {
     return options.map(function (option) {
       return option !== null ? [option, option.replace("aurora", "dev edition").replace("/", " ")] : null;
     });
-		   
+
   }
   return options.map(function (option) {
     return [option, option];
@@ -1080,6 +1080,23 @@ function getDescriptionLink(metric, channel, description) {
     link.append($("<i>", {
       class: "btn btn-outline-primary fa fa-info-circle",
     }).text(" More details"));
+  }
+
+  //Hide use counter link if not applicable.
+  if (metric.startsWith("USE_COUNTER") !== true) {
+    $(".use-counter-link")
+    .hide();
+  }
+
+  //Show correct use counter link based on group selection.
+  if (metric.startsWith("USE_COUNTER") === true) {
+    metricSplit = metric.split("_");
+    group = metricSplit[2];
+    useCounterLink = "http://georgf.github.io/usecounters/#kind=page&group=" + group + "&channel=beta&version=60";
+    $(".use-counter-link > a").attr('href', useCounterLink);
+    $(".use-counter-link")
+      .show();
+    console.log(useCounterLink);
   }
 
   return link;

--- a/new-pipeline/src/dashboards.js
+++ b/new-pipeline/src/dashboards.js
@@ -701,8 +701,8 @@ function getHumanReadableOptions(filterName, options) {
     return options.map(function (option) {
       return option !== null ? [option, option.replace("aurora", "dev edition").replace("/", " ")] : null;
     });
-
   }
+  
   return options.map(function (option) {
     return [option, option];
   });
@@ -1096,7 +1096,6 @@ function getDescriptionLink(metric, channel, description) {
     $(".use-counter-link > a").attr('href', useCounterLink);
     $(".use-counter-link")
       .show();
-    console.log(useCounterLink);
   }
 
   return link;


### PR DESCRIPTION
Hi @georgf , would you mind taking a look at this when you get the chance?

You can see it live [here](https://ecomerford.github.io/telemetry-dashboard/new-pipeline/dist.html#!cumulative=0&end_date=2018-03-08&keys=__none__!__none__!__none__&max_channel_version=nightly%252F60&measure=USE_COUNTER2_CONSOLE_TABLE_DOCUMENT&min_channel_version=nightly%252F57&processType=*&product=Firefox&sanitize=1&sort_keys=submissions&start_date=2018-01-22&table=0&trim=1&use_submission_date=0).

The only issue I'm having now is that if there is no data for the selection, the code doesn't create a new link, and if you switch to a non-use counter measure that doesn't have enough data to load a histogram, then the link does not get hidden. 

I'm not sure why this is happening- when I console log the `group` variable it seems to be updating each time regardless of the data. But when I console log the `useCounterLink` variable, that does not appear to be updating if there is too little data.

Do you have any thoughts on this?

Thank you!