### PR TITLE
Fix #521 : The description text and detail link should have a smaller (normal) font size in Measurement Dashboard

### DIFF
--- a/new-pipeline/style/dashboards.css
+++ b/new-pipeline/style/dashboards.css
@@ -129,19 +129,18 @@
   align-items: center;
   text-align: center;
   margin-bottom: 0;
+  font-size: medium;
 }
 
 .overflow {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  font-size: 1.5em;
   text-align: center;
 }
 
 #dist-caption-link, #evo-caption-link {
   color : black;
-  font-size: 1.5em;
   display: inline-block;
 }
 


### PR DESCRIPTION
#406 #501 For a better user experience, the description text and detail link should have a smaller (normal) font size in Measurement Dashboard.
One file is affected `dashboards.css`.
[Here](https://sylvia23.github.io/telemetry-dashboard/new-pipeline/dist.html#!cumulative=0&end_date=2018-04-02&keys=__none__!__none__!__none__&max_channel_version=beta%252F60&measure=GC_MS&min_channel_version=beta%252F57&processType=*&product=Firefox!Fennec&sanitize=1&sort_keys=submissions&start_date=2018-03-12&table=0&trim=1&use_submission_date=0) is the live link.

@georgf Please review. Thanks!