### PR TITLE
Fix #522 : Add Google Analytics to probe-dictionary

### DIFF
--- a/probe-dictionary/index.html
+++ b/probe-dictionary/index.html
@@ -21,6 +21,7 @@
   <!-- Font Awesome -->
   <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
 
+  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-49796218-2"></script>
 </head>
 
 <body>
@@ -193,5 +194,6 @@
   <!-- JS: D3 Visualization -->
   <script src="https://d3js.org/d3.v4.min.js"></script>
 
+  <script src="../analytics/analytics.js"></script>
 </body>
 </html>


### PR DESCRIPTION
We have Google Analytics to have insight into page-views on most pages.
We also want it for `probe-dictionary`.
One file is affected `probe-dictionary/index.html`.
@georgf Please see. Thanks!