### PR TITLE
Fix #528 : Remove link to Telemetry Experiments Monitoring from start page

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,9 +106,6 @@
                       Dashboard Generator
                       <div class="dashboard-description">Hand-craft your own dashboard with the push of a few buttons</div>
                     </a>
-                    <a class="list-group-item" href="https://bsmedberg.github.io/telemetry-experiments-dashboard/">
-                        Experiment Monitoring <div class="dashboard-description">View vitals and statistics for Firefox Telemetry Experiments.</div>
-                    </a>
                     <a class="list-group-item" href="http://alerts.telemetry.mozilla.org/">
                         Telemetry Alerts <div class="dashboard-description">Set up email alerts for significant performance changes.</div>
                     </a>


### PR DESCRIPTION
Telemetry Experiments are not used anymore and we are removing them. That means we can remove the experiments monitoring link from the start page.
One file is `index.html` affected.
@georgf Please have a look.