### PR TITLE
Fix #533 : Add a bug icon to the report a bug link on the landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
     <div class="container-fluid">
         <header>
             <form class="navbar-form inline pull-right">
-                <a href="https://github.com/mozilla/telemetry-dashboard/issues" class="btn" title="Report bugs in Telemetry dashboards">Report bug</a>
+                <a href="https://github.com/mozilla/telemetry-dashboard/issues" class="btn" title="Report bugs in Telemetry dashboards"><i class="fa fa-bug"></i> Report bug</a>
             </form>
             <h2>Telemetry portal</h2>
             <!-- <div class="error-msg">


### PR DESCRIPTION
We should add a `bug icon` to the `report a bug` link on the `landing page`. This would make it easier to recognize the link. I have used the `font-awesome bug icon` for that.
One file `index.html` is affected.
[Here](https://sylvia23.github.io/telemetry-dashboard/) is the live link.
@georgf Please review. Thanks!