### PR TITLE
Fix #516 : Update TMO frontend to handle 405s from aggregator

### DIFF
--- a/v2/telemetry.js
+++ b/v2/telemetry.js
@@ -477,8 +477,8 @@
   function populateEntriesMap(entriesMap, url, callback) {
     Telemetry.getJSON(url, function (histograms, status) {
       if (histograms === null) {
-        assert(status === 404 || status === 500 , "Could not obtain evolution: status " +
-          status + " (" + url + ")"); // Only allow null evolution if it is 404 or 500 - if there is no evolution for the given filters
+        assert(status === 404 || status === 500 || status === 405 , "Could not obtain evolution: status " +
+          status + " (" + url + ")"); // Only allow null evolution if it is 404, 500 or 405 - if there is no evolution for the given filters
         callback({});
       } else {
         histograms.data.forEach(function (entry) {


### PR DESCRIPTION
Handle of `405` response status in the same way as existing handling of `404` and `500` response status in case of bad query string.
One file `v2/telemetry.js` is affected.
@georgf @robhudson @fbertsch  @chutten 
Please review.
Thanks!