### PR TITLE
Fix #537 : Probe dictionary should not show all probes by default

### DIFF
--- a/probe-dictionary/explore.js
+++ b/probe-dictionary/explore.js
@@ -143,7 +143,6 @@ $(document).ready(function() {
     let date = new Date(gGeneralData.lastUpdate);
     $("#last-updated-date").text(date.toDateString());
 
-    $("#loading-overlay").addClass("hidden");
     mark("done");
   }, e => {
     console.log("caught", e);

--- a/probe-dictionary/explorer.css
+++ b/probe-dictionary/explorer.css
@@ -34,33 +34,6 @@ body {
     z-index: 15;
 }
 
-#loading-overlay {
-    position: absolute;
-    left: 0;
-    top: 0;
-    bottom: 0;
-    right: 0;
-    background: #000;
-    opacity: 0.7;
-    filter: alpha(opacity=70);
-    z-index: 14;
-}
-
-#loading-overlay .progress {
-    width: 76%;
-    /*height: 10%;*/
-    height: 30px;
-    position: absolute;
-    top: 50%;
-    left: 12%;
-    border: 6px solid grey;
-}
-
-#loading-overlay .progress-bar {
-    width: 100%;
-    height: 100%;
-}
-
 #last-updated {
     color: rgba(255, 255, 255, 0.65);
     font-size: 80%;

--- a/probe-dictionary/index.html
+++ b/probe-dictionary/index.html
@@ -68,13 +68,6 @@
     </nav>
   </div>
 
-  <!-- Loading overlay with progress bar. -->
-  <div id="loading-overlay">
-    <div class="progress">
-      <div class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100"></div>
-    </div>
-  </div>
-
   <!-- Search form. -->
   <div id="search-view">
 


### PR DESCRIPTION
It's a bit annoying to go to the probe-dictionary only to wait a few seconds while everything loads. Instead it should be blank, and searches should show results.
Making the loading indicator `non-modal` could solve the problem.
Three files `index.html`, `explore.js`, `explorer.css` are affected.
[Here](https://sylvia23.github.io/telemetry-dashboard/probe-dictionary/) is live link to check this.
@chutten @fbertsch @georgf Please have a look and suggest changes and additions.
