### PR TITLE
Specify analytics cookie domain

### DIFF
--- a/analytics/analytics.js
+++ b/analytics/analytics.js
@@ -23,7 +23,9 @@ if (window.trackingEnabled()) {
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
-  gtag('config', 'UA-49796218-2');
+  gtag('config', 'UA-49796218-2', {
+    'cookie_domain': 'telemetry.mozilla.org',
+  });
 
   // Decorate outbound links from the top frame of whitelisted pages
   const OUTBOUND_LINKS_WHITELIST = new Set([


### PR DESCRIPTION
gtag.js documentation allows us to customize the cookie name,
domain, and expiry. The defaults are "_ga" "auto" and "two years"
respectively.

"auto" here means that it will set it on .mozilla.org, which isn't what we
want. So let's restrict it to at most .telemetry.mozilla.org.