### PR TITLE
Fix to Issue #474: Link to use counter dashboard when necessary

### DIFF
--- a/new-pipeline/dist.html
+++ b/new-pipeline/dist.html
@@ -57,6 +57,9 @@
                         <option value="child">process type</option>
                     </select>
                 </h2>
+                <h4 class="use-counter-link">
+                  <a href="#">View in use counter dashboard.</a>
+                </h4>
                 <hr></hr>
                 <figure class="col-md-12">
                     <div class="caption-div">

--- a/new-pipeline/dist.html
+++ b/new-pipeline/dist.html
@@ -59,8 +59,9 @@
                 </h2>
                 <hr></hr>
                 <figure class="col-md-12">
+                    <div id="use-counter-link" style="text-align: center">
+                    </div>
                     <div class="caption-div">
-                        <figcaption id="use-counter-link"></figcaption>
                         <figcaption id="dist-caption-text" class="overflow"></figcaption>
                         <figcaption id="dist-caption-link"></figcaption>
                     </div>

--- a/new-pipeline/dist.html
+++ b/new-pipeline/dist.html
@@ -60,7 +60,7 @@
                 <hr></hr>
                 <figure class="col-md-12">
                   <div>
-                    <figcaption id="use-counter-link"></figcaption>
+                    <figcaption style="text-align: center" id="use-counter-link"></figcaption>
                   </div>
                   <div class="caption-div">
                     <figcaption id="dist-caption-text" class="overflow"></figcaption>

--- a/new-pipeline/dist.html
+++ b/new-pipeline/dist.html
@@ -58,11 +58,9 @@
                     </select>
                 </h2>
                 <hr></hr>
-                <h4 class="use-counter-link" style="text-align: center">
-                  <a href="#">View in use counter dashboard.</a>
-                </h4>
                 <figure class="col-md-12">
                     <div class="caption-div">
+                        <figcaption id="use-counter-link"></figcaption>
                         <figcaption id="dist-caption-text" class="overflow"></figcaption>
                         <figcaption id="dist-caption-link"></figcaption>
                     </div>

--- a/new-pipeline/dist.html
+++ b/new-pipeline/dist.html
@@ -59,91 +59,92 @@
                 </h2>
                 <hr></hr>
                 <figure class="col-md-12">
-                    <div id="use-counter-link" style="text-align: center">
-                    </div>
-                    <div class="caption-div">
-                        <figcaption id="dist-caption-text" class="overflow"></figcaption>
-                        <figcaption id="dist-caption-link"></figcaption>
-                    </div>
-                    <div class="col-md-9" id="plots">
-                        <div class="row">
-                            <div class="col-md-6" style="text-align: center">
-                                <h3><select id="selected-key1" class="multiselect" title="Selected key"></select></h3>
-                                <div style="margin-bottom: 20px; z-index: -1">
-                                    <div id="distribution1"></div>
-                                </div>
-                            </div>
-                            <div class="col-md-6" style="text-align: center">
-                                <h3><select id="selected-key2" class="multiselect" title="Selected key"></select></h3>
-                                <div style="margin-bottom: 20px; z-index: -1">
-                                    <div id="distribution2"></div>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="row">
-                            <div class="col-md-6" style="text-align: center">
-                                <h3><select id="selected-key3" class="multiselect" title="Selected key"></select></h3>
-                                <div style="margin-bottom: 20px; z-index: -1">
-                                    <div id="distribution3"></div>
-                                </div>
-                            </div>
-                            <div class="col-md-6" style="text-align: center">
-                                <h3><select id="selected-key4" class="multiselect" title="Selected key"></select></h3>
-                                <div style="margin-bottom: 20px; z-index: -1">
-                                    <div id="distribution4"></div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="col-md-3" style="padding-top: 7em">
-                        <div id="summary">
-                            <dl class="dl-horizontal" style="margin-top: 1em">
-                                <dt title="The type of the histogram (e.g., linear, exponential, Boolean)">Histogram Type</dt><dd id="prop-kind"></dd>
-                                <dt title="Total number of Telemetry pings shown">Ping Count</dt><dd id="prop-submissions"></dd>
-                                <dt title="Total number of measurements shown">Sample Count</dt><dd id="prop-count"></dd>
-                                <dt title="Sum of all sample values inserted into the histogram">Sample Sum</dt><dd id="prop-sum"></dd>
-                                <dt title="Number of distinct dates shown">Number of dates</dt><dd id="prop-dates"></dd>
-                                <dt title="Range of dates currently shown">Selected Dates</dt><dd id="prop-date-range"></dd>
-                            </dl>
-                            <div class="scalar-only" style="margin-top: 50px">
-                                <dl class="dl-horizontal">
-                                    <dt>5th Percentile</dt><dd id="prop-p5"></dd>
-                                    <dt>25th Percentile</dt><dd id="prop-p25"></dd>
-                                    <dt>Median</dt><dd id="prop-p50"></dd>
-                                    <dt>75th Percentile</dt><dd id="prop-p75"></dd>
-                                    <dt>95th Percentile</dt><dd id="prop-p95"></dd>
-                                    <br>
-                                    <div style="font-size: 80%; margin: 0 20%">
-                                        <strong>Notice</strong> percentiles are estimated based on values in the histogram. Values are only guaranteed to be accurate to the nearest bucket.
-                                    </div>
-                                </dl>
-                            </div>
-                        </div>
-                        <div id="stats-comparison" style="margin-top: 50px; margin-bottom: 20px;">
-                            <table>
-                              <thead class="measure-headers">
-                              <tr>
-                              <th></th>
-                              <th title="5th percentile duration">5 %</th>
-                              <th title="25th percentile duration">25 %</th>
-                              <th title="Median duration">Median</th>
-                              <th title="75th percentile duration">75 %</th>
-                              <th title="95th percentile duration">95 %</th>
-                              </tr>
-                              </thead>
-                              <tbody id="histogram-percentiles" class="measure-values">
-                                  <tr>
-                                  <td colspan="6">No Data</td>
-                                  </tr>
-                              </tbody>
-                            </table>
-                        </div>
-                        <div style="text-align: center">
-                            <a class="btn btn-default btn-sm" id="export-csv" title="Export the current histogram to CSV">Export CSV</a>
-                            <a class="btn btn-default btn-sm" id="export-json" title="Export the current histogram to JSON">Export JSON</a>
-                        </div>
-                    </div>
-                </figure>
+                  <div>
+                    <figcaption id="use-counter-link"></figcaption>
+                  </div>
+                  <div class="caption-div">
+                    <figcaption id="dist-caption-text" class="overflow"></figcaption>
+                    <figcaption id="dist-caption-link"></figcaption>
+                  </div>
+                  <div class="col-md-9" id="plots">
+                      <div class="row">
+                          <div class="col-md-6" style="text-align: center">
+                              <h3><select id="selected-key1" class="multiselect" title="Selected key"></select></h3>
+                              <div style="margin-bottom: 20px; z-index: -1">
+                                  <div id="distribution1"></div>
+                              </div>
+                          </div>
+                          <div class="col-md-6" style="text-align: center">
+                              <h3><select id="selected-key2" class="multiselect" title="Selected key"></select></h3>
+                              <div style="margin-bottom: 20px; z-index: -1">
+                                  <div id="distribution2"></div>
+                              </div>
+                          </div>
+                      </div>
+                      <div class="row">
+                          <div class="col-md-6" style="text-align: center">
+                              <h3><select id="selected-key3" class="multiselect" title="Selected key"></select></h3>
+                              <div style="margin-bottom: 20px; z-index: -1">
+                                  <div id="distribution3"></div>
+                              </div>
+                          </div>
+                          <div class="col-md-6" style="text-align: center">
+                              <h3><select id="selected-key4" class="multiselect" title="Selected key"></select></h3>
+                              <div style="margin-bottom: 20px; z-index: -1">
+                                  <div id="distribution4"></div>
+                              </div>
+                          </div>
+                      </div>
+                  </div>
+                  <div class="col-md-3" style="padding-top: 7em">
+                      <div id="summary">
+                          <dl class="dl-horizontal" style="margin-top: 1em">
+                              <dt title="The type of the histogram (e.g., linear, exponential, Boolean)">Histogram Type</dt><dd id="prop-kind"></dd>
+                              <dt title="Total number of Telemetry pings shown">Ping Count</dt><dd id="prop-submissions"></dd>
+                              <dt title="Total number of measurements shown">Sample Count</dt><dd id="prop-count"></dd>
+                              <dt title="Sum of all sample values inserted into the histogram">Sample Sum</dt><dd id="prop-sum"></dd>
+                              <dt title="Number of distinct dates shown">Number of dates</dt><dd id="prop-dates"></dd>
+                              <dt title="Range of dates currently shown">Selected Dates</dt><dd id="prop-date-range"></dd>
+                          </dl>
+                          <div class="scalar-only" style="margin-top: 50px">
+                              <dl class="dl-horizontal">
+                                  <dt>5th Percentile</dt><dd id="prop-p5"></dd>
+                                  <dt>25th Percentile</dt><dd id="prop-p25"></dd>
+                                  <dt>Median</dt><dd id="prop-p50"></dd>
+                                  <dt>75th Percentile</dt><dd id="prop-p75"></dd>
+                                  <dt>95th Percentile</dt><dd id="prop-p95"></dd>
+                                  <br>
+                                  <div style="font-size: 80%; margin: 0 20%">
+                                      <strong>Notice</strong> percentiles are estimated based on values in the histogram. Values are only guaranteed to be accurate to the nearest bucket.
+                                  </div>
+                              </dl>
+                          </div>
+                      </div>
+                      <div id="stats-comparison" style="margin-top: 50px; margin-bottom: 20px;">
+                          <table>
+                            <thead class="measure-headers">
+                            <tr>
+                            <th></th>
+                            <th title="5th percentile duration">5 %</th>
+                            <th title="25th percentile duration">25 %</th>
+                            <th title="Median duration">Median</th>
+                            <th title="75th percentile duration">75 %</th>
+                            <th title="95th percentile duration">95 %</th>
+                            </tr>
+                            </thead>
+                            <tbody id="histogram-percentiles" class="measure-values">
+                                <tr>
+                                <td colspan="6">No Data</td>
+                                </tr>
+                            </tbody>
+                          </table>
+                      </div>
+                      <div style="text-align: center">
+                          <a class="btn btn-default btn-sm" id="export-csv" title="Export the current histogram to CSV">Export CSV</a>
+                          <a class="btn btn-default btn-sm" id="export-json" title="Export the current histogram to JSON">Export JSON</a>
+                      </div>
+                  </div>
+              </figure>
             </div>
         </div>
         <div class="row">

--- a/new-pipeline/dist.html
+++ b/new-pipeline/dist.html
@@ -57,10 +57,10 @@
                         <option value="child">process type</option>
                     </select>
                 </h2>
-                <h4 class="use-counter-link">
+                <hr></hr>
+                <h4 class="use-counter-link" style="text-align: center">
                   <a href="#">View in use counter dashboard.</a>
                 </h4>
-                <hr></hr>
                 <figure class="col-md-12">
                     <div class="caption-div">
                         <figcaption id="dist-caption-text" class="overflow"></figcaption>

--- a/new-pipeline/dist.html
+++ b/new-pipeline/dist.html
@@ -59,92 +59,92 @@
                 </h2>
                 <hr></hr>
                 <figure class="col-md-12">
-                  <div>
-                    <figcaption style="text-align: center" id="use-counter-link"></figcaption>
-                  </div>
-                  <div class="caption-div">
-                    <figcaption id="dist-caption-text" class="overflow"></figcaption>
-                    <figcaption id="dist-caption-link"></figcaption>
-                  </div>
-                  <div class="col-md-9" id="plots">
-                      <div class="row">
-                          <div class="col-md-6" style="text-align: center">
-                              <h3><select id="selected-key1" class="multiselect" title="Selected key"></select></h3>
-                              <div style="margin-bottom: 20px; z-index: -1">
-                                  <div id="distribution1"></div>
-                              </div>
-                          </div>
-                          <div class="col-md-6" style="text-align: center">
-                              <h3><select id="selected-key2" class="multiselect" title="Selected key"></select></h3>
-                              <div style="margin-bottom: 20px; z-index: -1">
-                                  <div id="distribution2"></div>
-                              </div>
-                          </div>
-                      </div>
-                      <div class="row">
-                          <div class="col-md-6" style="text-align: center">
-                              <h3><select id="selected-key3" class="multiselect" title="Selected key"></select></h3>
-                              <div style="margin-bottom: 20px; z-index: -1">
-                                  <div id="distribution3"></div>
-                              </div>
-                          </div>
-                          <div class="col-md-6" style="text-align: center">
-                              <h3><select id="selected-key4" class="multiselect" title="Selected key"></select></h3>
-                              <div style="margin-bottom: 20px; z-index: -1">
-                                  <div id="distribution4"></div>
-                              </div>
-                          </div>
-                      </div>
-                  </div>
-                  <div class="col-md-3" style="padding-top: 7em">
-                      <div id="summary">
-                          <dl class="dl-horizontal" style="margin-top: 1em">
-                              <dt title="The type of the histogram (e.g., linear, exponential, Boolean)">Histogram Type</dt><dd id="prop-kind"></dd>
-                              <dt title="Total number of Telemetry pings shown">Ping Count</dt><dd id="prop-submissions"></dd>
-                              <dt title="Total number of measurements shown">Sample Count</dt><dd id="prop-count"></dd>
-                              <dt title="Sum of all sample values inserted into the histogram">Sample Sum</dt><dd id="prop-sum"></dd>
-                              <dt title="Number of distinct dates shown">Number of dates</dt><dd id="prop-dates"></dd>
-                              <dt title="Range of dates currently shown">Selected Dates</dt><dd id="prop-date-range"></dd>
-                          </dl>
-                          <div class="scalar-only" style="margin-top: 50px">
-                              <dl class="dl-horizontal">
-                                  <dt>5th Percentile</dt><dd id="prop-p5"></dd>
-                                  <dt>25th Percentile</dt><dd id="prop-p25"></dd>
-                                  <dt>Median</dt><dd id="prop-p50"></dd>
-                                  <dt>75th Percentile</dt><dd id="prop-p75"></dd>
-                                  <dt>95th Percentile</dt><dd id="prop-p95"></dd>
-                                  <br>
-                                  <div style="font-size: 80%; margin: 0 20%">
-                                      <strong>Notice</strong> percentiles are estimated based on values in the histogram. Values are only guaranteed to be accurate to the nearest bucket.
-                                  </div>
-                              </dl>
-                          </div>
-                      </div>
-                      <div id="stats-comparison" style="margin-top: 50px; margin-bottom: 20px;">
-                          <table>
-                            <thead class="measure-headers">
-                            <tr>
-                            <th></th>
-                            <th title="5th percentile duration">5 %</th>
-                            <th title="25th percentile duration">25 %</th>
-                            <th title="Median duration">Median</th>
-                            <th title="75th percentile duration">75 %</th>
-                            <th title="95th percentile duration">95 %</th>
-                            </tr>
-                            </thead>
-                            <tbody id="histogram-percentiles" class="measure-values">
-                                <tr>
-                                <td colspan="6">No Data</td>
-                                </tr>
-                            </tbody>
-                          </table>
-                      </div>
-                      <div style="text-align: center">
-                          <a class="btn btn-default btn-sm" id="export-csv" title="Export the current histogram to CSV">Export CSV</a>
-                          <a class="btn btn-default btn-sm" id="export-json" title="Export the current histogram to JSON">Export JSON</a>
-                      </div>
-                  </div>
-              </figure>
+                    <div class="caption-div">
+                        <figcaption id="dist-caption-text" class="overflow"></figcaption>
+                        <figcaption id="dist-caption-link"></figcaption>
+                    </div>
+                    <div class="use-counter-div">
+                        <figcaption id="use-counter-link"></figcaption>
+                    </div>
+                    <div class="col-md-9" id="plots">
+                        <div class="row">
+                            <div class="col-md-6" style="text-align: center">
+                                <h3><select id="selected-key1" class="multiselect" title="Selected key"></select></h3>
+                                <div style="margin-bottom: 20px; z-index: -1">
+                                    <div id="distribution1"></div>
+                                </div>
+                            </div>
+                            <div class="col-md-6" style="text-align: center">
+                                <h3><select id="selected-key2" class="multiselect" title="Selected key"></select></h3>
+                                <div style="margin-bottom: 20px; z-index: -1">
+                                    <div id="distribution2"></div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-md-6" style="text-align: center">
+                                <h3><select id="selected-key3" class="multiselect" title="Selected key"></select></h3>
+                                <div style="margin-bottom: 20px; z-index: -1">
+                                    <div id="distribution3"></div>
+                                </div>
+                            </div>
+                            <div class="col-md-6" style="text-align: center">
+                                <h3><select id="selected-key4" class="multiselect" title="Selected key"></select></h3>
+                                <div style="margin-bottom: 20px; z-index: -1">
+                                    <div id="distribution4"></div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-md-3" style="padding-top: 7em">
+                        <div id="summary">
+                            <dl class="dl-horizontal" style="margin-top: 1em">
+                                <dt title="The type of the histogram (e.g., linear, exponential, Boolean)">Histogram Type</dt><dd id="prop-kind"></dd>
+                                <dt title="Total number of Telemetry pings shown">Ping Count</dt><dd id="prop-submissions"></dd>
+                                <dt title="Total number of measurements shown">Sample Count</dt><dd id="prop-count"></dd>
+                                <dt title="Sum of all sample values inserted into the histogram">Sample Sum</dt><dd id="prop-sum"></dd>
+                                <dt title="Number of distinct dates shown">Number of dates</dt><dd id="prop-dates"></dd>
+                                <dt title="Range of dates currently shown">Selected Dates</dt><dd id="prop-date-range"></dd>
+                            </dl>
+                            <div class="scalar-only" style="margin-top: 50px">
+                                <dl class="dl-horizontal">
+                                    <dt>5th Percentile</dt><dd id="prop-p5"></dd>
+                                    <dt>25th Percentile</dt><dd id="prop-p25"></dd>
+                                    <dt>Median</dt><dd id="prop-p50"></dd>
+                                    <dt>75th Percentile</dt><dd id="prop-p75"></dd>
+                                    <dt>95th Percentile</dt><dd id="prop-p95"></dd>
+                                    <br>
+                                    <div style="font-size: 80%; margin: 0 20%">
+                                        <strong>Notice</strong> percentiles are estimated based on values in the histogram. Values are only guaranteed to be accurate to the nearest bucket.
+                                    </div>
+                                </dl>
+                            </div>
+                        </div>
+                        <div id="stats-comparison" style="margin-top: 50px; margin-bottom: 20px;">
+                            <table>
+                              <thead class="measure-headers">
+                              <tr>
+                              <th></th>
+                              <th title="5th percentile duration">5 %</th>
+                              <th title="25th percentile duration">25 %</th>
+                              <th title="Median duration">Median</th>
+                              <th title="75th percentile duration">75 %</th>
+                              <th title="95th percentile duration">95 %</th>
+                              </tr>
+                              </thead>
+                              <tbody id="histogram-percentiles" class="measure-values">
+                                  <tr>
+                                  <td colspan="6">No Data</td>
+                                  </tr>
+                              </tbody>
+                            </table>
+                        </div>
+                        <div style="text-align: center">
+                            <a class="btn btn-default btn-sm" id="export-csv" title="Export the current histogram to CSV">Export CSV</a>
+                            <a class="btn btn-default btn-sm" id="export-json" title="Export the current histogram to JSON">Export JSON</a>
+                        </div>
+                    </div>
+                </figure>
             </div>
         </div>
         <div class="row">

--- a/new-pipeline/evo.html
+++ b/new-pipeline/evo.html
@@ -4,12 +4,15 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    
     <title>Evolution Dashboard</title>
+    
     <!-- Bootstrap and supporting libraries -->
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
     <link rel="stylesheet" href="style/bootstrap-multiselect.css" type="text/css"/>
     <link rel="stylesheet" type="text/css" href="style/metricsgraphics.css" />
+    
     <link rel="stylesheet" type="text/css" href="style/dashboards.css" />
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-49796218-2"></script>
 </head>
@@ -110,17 +113,21 @@
         <span class="busy-indicator-message">Loading page...</span>
     </div>
     <div><a href="https://www.mozilla.org/en-US/privacy/websites/">Mozilla's Website Privacy Notice</a></div>
+    
     <!-- Bootstrap and supporting libraries -->
     <script src="https://code.jquery.com/jquery-1.11.3.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
     <script type="text/javascript" src="lib/bootstrap-multiselect.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.10.2/moment.min.js"></script>
+    
     <!-- MetricsGraphics libraries -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.5/d3.min.js" charset="utf-8"></script>
     <script src="lib/metricsgraphics.min.js"></script>
+ 
     <script src="../v2/telemetry.js"></script>
     <script src="src/dashboards.js"></script>
     <script src="src/evo.js"></script>
+    
     <script src="../analytics/analytics.js"></script>
 </body>
 </html>

--- a/new-pipeline/evo.html
+++ b/new-pipeline/evo.html
@@ -4,15 +4,12 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-
     <title>Evolution Dashboard</title>
-
     <!-- Bootstrap and supporting libraries -->
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
     <link rel="stylesheet" href="style/bootstrap-multiselect.css" type="text/css"/>
     <link rel="stylesheet" type="text/css" href="style/metricsgraphics.css" />
-
     <link rel="stylesheet" type="text/css" href="style/dashboards.css" />
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-49796218-2"></script>
 </head>
@@ -113,21 +110,17 @@
         <span class="busy-indicator-message">Loading page...</span>
     </div>
     <div><a href="https://www.mozilla.org/en-US/privacy/websites/">Mozilla's Website Privacy Notice</a></div>
-
     <!-- Bootstrap and supporting libraries -->
     <script src="https://code.jquery.com/jquery-1.11.3.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
     <script type="text/javascript" src="lib/bootstrap-multiselect.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.10.2/moment.min.js"></script>
-
     <!-- MetricsGraphics libraries -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.5/d3.min.js" charset="utf-8"></script>
     <script src="lib/metricsgraphics.min.js"></script>
-
     <script src="../v2/telemetry.js"></script>
     <script src="src/dashboards.js"></script>
     <script src="src/evo.js"></script>
-
     <script src="../analytics/analytics.js"></script>
 </body>
 </html>

--- a/new-pipeline/evo.html
+++ b/new-pipeline/evo.html
@@ -59,13 +59,11 @@
                     <select id="filter-process-type" class="multiselect" title="Process type" data-all-selected="any process type"></select>
                 </h2>
                 <hr></hr>
-                <figure class="col-md-12">
-                  <div id="use-counter-link" style="text-align: center"></div>
-                  <div class="caption-div">
-                      <figcaption id="evo-caption-text" class="overflow"></figcaption>
-                      <figcaption id="evo-caption-link"></figcaption>
-                  </div>
-                </figure> 
+                <h2 id="use-counter-link" style="text-align: center"></h2>
+                <div class="caption-div">
+                    <figcaption id="evo-caption-text" class="overflow"></figcaption>
+                    <figcaption id="evo-caption-link"></figcaption>
+                </div>
                 <h2 style="font-size: 18px; margin-bottom: 0">Showing graphs for key <select id="selected-key" class="multiselect" title="Selected key"></select></h2>
                 <figure class="col-md-12">
                     <div class="col-md-12" id="evolutions"></div>

--- a/new-pipeline/evo.html
+++ b/new-pipeline/evo.html
@@ -4,15 +4,15 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    
+
     <title>Evolution Dashboard</title>
-    
+
     <!-- Bootstrap and supporting libraries -->
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
     <link rel="stylesheet" href="style/bootstrap-multiselect.css" type="text/css"/>
     <link rel="stylesheet" type="text/css" href="style/metricsgraphics.css" />
-    
+
     <link rel="stylesheet" type="text/css" href="style/dashboards.css" />
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-49796218-2"></script>
 </head>
@@ -58,13 +58,16 @@
                     as
                     <select id="filter-process-type" class="multiselect" title="Process type" data-all-selected="any process type"></select>
                 </h2>
+                <h4 class="use-counter-link">
+                  <a href="#">View in use counter dashboard.</a>
+                </h4>
                 <hr></hr>
                 <div class="caption-div">
                     <figcaption id="evo-caption-text" class="overflow"></figcaption>
                     <figcaption id="evo-caption-link"></figcaption>
-                </div> 
-                
-                <h2 style="font-size: 18px; margin-bottom: 0">Showing graphs for key <select id="selected-key" class="multiselect" title="Selected key"></select></h2>          
+                </div>
+
+                <h2 style="font-size: 18px; margin-bottom: 0">Showing graphs for key <select id="selected-key" class="multiselect" title="Selected key"></select></h2>
                 <figure class="col-md-12">
                     <div class="col-md-12" id="evolutions"></div>
                 </figure>
@@ -110,13 +113,13 @@
         <span class="busy-indicator-message">Loading page...</span>
     </div>
     <div><a href="https://www.mozilla.org/en-US/privacy/websites/">Mozilla's Website Privacy Notice</a></div>
-    
+
     <!-- Bootstrap and supporting libraries -->
     <script src="https://code.jquery.com/jquery-1.11.3.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
     <script type="text/javascript" src="lib/bootstrap-multiselect.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.10.2/moment.min.js"></script>
-    
+
     <!-- MetricsGraphics libraries -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.5/d3.min.js" charset="utf-8"></script>
     <script src="lib/metricsgraphics.min.js"></script>

--- a/new-pipeline/evo.html
+++ b/new-pipeline/evo.html
@@ -59,10 +59,12 @@
                     <select id="filter-process-type" class="multiselect" title="Process type" data-all-selected="any process type"></select>
                 </h2>
                 <hr></hr>
-                <div id="use-counter-link" style="text-align: center"></div>
+                <div>
+                  <figcaption id="use-counter-link"></figcaption>
+                </div>
                 <div class="caption-div">
-                    <figcaption id="evo-caption-text" class="overflow"></figcaption>
-                    <figcaption id="evo-caption-link"></figcaption>
+                  <figcaption id="evo-caption-text" class="overflow"></figcaption>
+                  <figcaption id="evo-caption-link"></figcaption>
                 </div>
                 <h2 style="font-size: 18px; margin-bottom: 0">Showing graphs for key <select id="selected-key" class="multiselect" title="Selected key"></select></h2>
                 <figure class="col-md-12">

--- a/new-pipeline/evo.html
+++ b/new-pipeline/evo.html
@@ -59,7 +59,7 @@
                     <select id="filter-process-type" class="multiselect" title="Process type" data-all-selected="any process type"></select>
                 </h2>
                 <hr></hr>
-                <h2 id="use-counter-link" style="text-align: center"></h2>
+                <div id="use-counter-link" style="text-align: center"></div>
                 <div class="caption-div">
                     <figcaption id="evo-caption-text" class="overflow"></figcaption>
                     <figcaption id="evo-caption-link"></figcaption>

--- a/new-pipeline/evo.html
+++ b/new-pipeline/evo.html
@@ -4,15 +4,15 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    
+
     <title>Evolution Dashboard</title>
-    
+
     <!-- Bootstrap and supporting libraries -->
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
     <link rel="stylesheet" href="style/bootstrap-multiselect.css" type="text/css"/>
     <link rel="stylesheet" type="text/css" href="style/metricsgraphics.css" />
-    
+
     <link rel="stylesheet" type="text/css" href="style/dashboards.css" />
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-49796218-2"></script>
 </head>
@@ -58,10 +58,10 @@
                     as
                     <select id="filter-process-type" class="multiselect" title="Process type" data-all-selected="any process type"></select>
                 </h2>
-                <h4 class="use-counter-link">
+                <hr></hr>
+                <h4 class="use-counter-link" style="text-align: center">
                   <a href="#">View in use counter dashboard.</a>
                 </h4>
-                <hr></hr>
                 <div class="caption-div">
                     <figcaption id="evo-caption-text" class="overflow"></figcaption>
                     <figcaption id="evo-caption-link"></figcaption>
@@ -111,21 +111,21 @@
         <span class="busy-indicator-message">Loading page...</span>
     </div>
     <div><a href="https://www.mozilla.org/en-US/privacy/websites/">Mozilla's Website Privacy Notice</a></div>
-    
+
     <!-- Bootstrap and supporting libraries -->
     <script src="https://code.jquery.com/jquery-1.11.3.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
     <script type="text/javascript" src="lib/bootstrap-multiselect.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.10.2/moment.min.js"></script>
-    
+
     <!-- MetricsGraphics libraries -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.5/d3.min.js" charset="utf-8"></script>
     <script src="lib/metricsgraphics.min.js"></script>
- 
+
     <script src="../v2/telemetry.js"></script>
     <script src="src/dashboards.js"></script>
     <script src="src/evo.js"></script>
-    
+
     <script src="../analytics/analytics.js"></script>
 </body>
 </html>

--- a/new-pipeline/evo.html
+++ b/new-pipeline/evo.html
@@ -59,14 +59,11 @@
                     <select id="filter-process-type" class="multiselect" title="Process type" data-all-selected="any process type"></select>
                 </h2>
                 <hr></hr>
-                <h4 class="use-counter-link" style="text-align: center">
-                  <a href="#">View in use counter dashboard.</a>
-                </h4>
                 <div class="caption-div">
+                    <figcaption id="use-counter-link"></figcaption>
                     <figcaption id="evo-caption-text" class="overflow"></figcaption>
                     <figcaption id="evo-caption-link"></figcaption>
                 </div>
-
                 <h2 style="font-size: 18px; margin-bottom: 0">Showing graphs for key <select id="selected-key" class="multiselect" title="Selected key"></select></h2>
                 <figure class="col-md-12">
                     <div class="col-md-12" id="evolutions"></div>

--- a/new-pipeline/evo.html
+++ b/new-pipeline/evo.html
@@ -59,12 +59,12 @@
                     <select id="filter-process-type" class="multiselect" title="Process type" data-all-selected="any process type"></select>
                 </h2>
                 <hr></hr>
-                <div>
-                  <figcaption style="text-align: center" id="use-counter-link"></figcaption>
-                </div>
                 <div class="caption-div">
-                  <figcaption id="evo-caption-text" class="overflow"></figcaption>
-                  <figcaption id="evo-caption-link"></figcaption>
+                    <figcaption id="evo-caption-text" class="overflow"></figcaption>
+                    <figcaption id="evo-caption-link"></figcaption>
+                </div>
+                <div class=use-counter-div>
+                    <figcaption id="use-counter-link"></figcaption>
                 </div>
                 <h2 style="font-size: 18px; margin-bottom: 0">Showing graphs for key <select id="selected-key" class="multiselect" title="Selected key"></select></h2>
                 <figure class="col-md-12">

--- a/new-pipeline/evo.html
+++ b/new-pipeline/evo.html
@@ -60,7 +60,7 @@
                 </h2>
                 <hr></hr>
                 <div>
-                  <figcaption id="use-counter-link"></figcaption>
+                  <figcaption style="text-align: center" id="use-counter-link"></figcaption>
                 </div>
                 <div class="caption-div">
                   <figcaption id="evo-caption-text" class="overflow"></figcaption>

--- a/new-pipeline/evo.html
+++ b/new-pipeline/evo.html
@@ -59,11 +59,13 @@
                     <select id="filter-process-type" class="multiselect" title="Process type" data-all-selected="any process type"></select>
                 </h2>
                 <hr></hr>
-                <div class="caption-div">
-                    <figcaption id="use-counter-link"></figcaption>
-                    <figcaption id="evo-caption-text" class="overflow"></figcaption>
-                    <figcaption id="evo-caption-link"></figcaption>
-                </div>
+                <figure class="col-md-12">
+                  <div id="use-counter-link" style="text-align: center"></div>
+                  <div class="caption-div">
+                      <figcaption id="evo-caption-text" class="overflow"></figcaption>
+                      <figcaption id="evo-caption-link"></figcaption>
+                  </div>
+                </figure> 
                 <h2 style="font-size: 18px; margin-bottom: 0">Showing graphs for key <select id="selected-key" class="multiselect" title="Selected key"></select></h2>
                 <figure class="col-md-12">
                     <div class="col-md-12" id="evolutions"></div>

--- a/new-pipeline/src/dashboards.js
+++ b/new-pipeline/src/dashboards.js
@@ -1097,7 +1097,7 @@ function getUseCounterLink(metric, channel, description) {
     });
     useCounterLink.append($"<i>", {
       class: "btn btn-outline-primary fa fa-info-circle",
-    }).text(" View in use counter dashboard.");
+    }).text(" View in use counter dashboard."));
   else {
     return null;
   }

--- a/new-pipeline/src/dashboards.js
+++ b/new-pipeline/src/dashboards.js
@@ -1085,20 +1085,20 @@ function getDescriptionLink(metric, channel, description) {
 }
 
 function getUseCounterLink(metric, channel, description) {
+  var metric = metric;
   if (metric.startsWith("USE_COUNTER") !== true) {
     return null;
   }
   else {
-    var metricUrl = buildDictionaryURL(metric, channel, description);
-      metricSplit = metric.split("_");
-      var group = metricSplit[2];
-      var useCounterLink = $("<a>", {
-        href: "http://georgf.github.io/usecounters/#kind=page&group=" + group + "&channel=beta&version=60",
-        target: "_blank",
-      });
-      useCounterLink.append($("<i>", {
-        class: "btn btn-outline-primary fa fa-info-circle",
-      }).text(" View in use counter dashboard."));
+    metricSplit = metric.split("_");
+    var group = metricSplit[2];
+    var useCounterLink = $("<a>", {
+      href: "http://georgf.github.io/usecounters/#kind=page&group=" + group + "&channel=beta&version=60",
+      target: "_blank",
+    });
+    useCounterLink.append($("<i>", {
+      class: "btn btn-outline-primary fa fa-info-circle",
+    }).text(" View in use counter dashboard."));
     return useCounterLink;
   }
 }

--- a/new-pipeline/src/dashboards.js
+++ b/new-pipeline/src/dashboards.js
@@ -1085,12 +1085,13 @@ function getDescriptionLink(metric, channel, description) {
 }
 
 function getUseCounterLink(metric, channel, description) {
-  if (metric.startsWith("USE_COUNTER") !== true) {
+  var measure = metric;
+  if (measure.startsWith("USE_COUNTER") !== true) {
     return null;
   }
   else {
-    metricSplit = metric.split("_");
-    var group = metricSplit[2];
+    measureSplit = measure.split("_");
+    var group = measureSplit[2];
     var useCounterLink = $("<a>", {
       href: "http://georgf.github.io/usecounters/#kind=page&group=" + group + "&channel=beta&version=60",
       target: "_blank",

--- a/new-pipeline/src/dashboards.js
+++ b/new-pipeline/src/dashboards.js
@@ -1081,6 +1081,7 @@ function getDescriptionLink(metric, channel, description) {
       class: "btn btn-outline-primary fa fa-info-circle",
     }).text(" More details"));
   }
+  return link;
 }
 
 function useCounterLink(metric, channel, description) {
@@ -1100,6 +1101,4 @@ function useCounterLink(metric, channel, description) {
     $(".use-counter-link")
       .show();
   }
-
-  return link;
 }

--- a/new-pipeline/src/dashboards.js
+++ b/new-pipeline/src/dashboards.js
@@ -1085,7 +1085,6 @@ function getDescriptionLink(metric, channel, description) {
 }
 
 function getUseCounterLink(metric, channel, description) {
-  var metric = metric;
   if (metric.startsWith("USE_COUNTER") !== true) {
     return null;
   }

--- a/new-pipeline/src/dashboards.js
+++ b/new-pipeline/src/dashboards.js
@@ -702,7 +702,7 @@ function getHumanReadableOptions(filterName, options) {
       return option !== null ? [option, option.replace("aurora", "dev edition").replace("/", " ")] : null;
     });
   }
-  
+
   return options.map(function (option) {
     return [option, option];
   });
@@ -1081,7 +1081,10 @@ function getDescriptionLink(metric, channel, description) {
       class: "btn btn-outline-primary fa fa-info-circle",
     }).text(" More details"));
   }
+}
 
+function useCounterLink(metric, channel, description) {
+  var metricUrl = buildDictionaryURL(metric, channel, description);
   //Hide use counter link if not applicable.
   if (metric.startsWith("USE_COUNTER") !== true) {
     $(".use-counter-link")

--- a/new-pipeline/src/dashboards.js
+++ b/new-pipeline/src/dashboards.js
@@ -1085,19 +1085,20 @@ function getDescriptionLink(metric, channel, description) {
 }
 
 function getUseCounterLink(metric, channel, description) {
-  var metricUrl = buildDictionaryURL(metric, channel, description);
   if (metric.startsWith("USE_COUNTER") !== true) {
-    $(".use-counter-link").text(""); // Clear use counter link;
+    return useCounterLink;
   }
-  //Show correct use counter link based on group selection.
-  else {
+  var metricUrl = buildDictionaryURL(metric, channel, description);
     metricSplit = metric.split("_");
     var group = metricSplit[2];
     var useCounterLink = $("<a>", {
       href: "http://georgf.github.io/usecounters/#kind=page&group=" + group + "&channel=beta&version=60",
       target: "_blank",
     });
-    useCounterLink.text("View in use counter dashboard.");
+    useCounterLink.append($"<i>", {
+      class: "btn btn-outline-primary fa fa-info-circle",
+    }).text(" View in use counter dashboard.");
+  else {
+    return null;
   }
-  return useCounterLink;
 }

--- a/new-pipeline/src/dashboards.js
+++ b/new-pipeline/src/dashboards.js
@@ -1087,16 +1087,17 @@ function getDescriptionLink(metric, channel, description) {
 function showUseCounterLink(metric, channel, description) {
   //Show correct use counter link based on group selection.
   var metricUrl = buildDictionaryURL(metric, channel, description);
-  if (metric.startsWith("USE_COUNTER") === true) {
+  if (metric.startsWith("USE_COUNTER") !== true) {
+    $(".use-counter-link")
+    .text("");
+  }
+
+  else {
     metricSplit = metric.split("_");
     var group = metricSplit[2];
     var useCounterLink = $("<a>", {
       href: "http://georgf.github.io/usecounters/#kind=page&group=" + group + "&channel=beta&version=60",
       target: "_blank",
-      css: {
-        color: "black",
-      },
-      "aria-hidden": "true",
     });
     useCounterLink.text("View in use counter dashboard.");
   }

--- a/new-pipeline/src/dashboards.js
+++ b/new-pipeline/src/dashboards.js
@@ -1086,19 +1086,19 @@ function getDescriptionLink(metric, channel, description) {
 
 function getUseCounterLink(metric, channel, description) {
   if (metric.startsWith("USE_COUNTER") !== true) {
-    return useCounterLink;
-  }
-  var metricUrl = buildDictionaryURL(metric, channel, description);
-    metricSplit = metric.split("_");
-    var group = metricSplit[2];
-    var useCounterLink = $("<a>", {
-      href: "http://georgf.github.io/usecounters/#kind=page&group=" + group + "&channel=beta&version=60",
-      target: "_blank",
-    });
-    useCounterLink.append($("<i>", {
-      class: "btn btn-outline-primary fa fa-info-circle",
-    }).text(" View in use counter dashboard."));
-  else {
     return null;
+  }
+  else {
+    var metricUrl = buildDictionaryURL(metric, channel, description);
+      metricSplit = metric.split("_");
+      var group = metricSplit[2];
+      var useCounterLink = $("<a>", {
+        href: "http://georgf.github.io/usecounters/#kind=page&group=" + group + "&channel=beta&version=60",
+        target: "_blank",
+      });
+      useCounterLink.append($("<i>", {
+        class: "btn btn-outline-primary fa fa-info-circle",
+      }).text(" View in use counter dashboard."));
+    return useCounterLink;
   }
 }

--- a/new-pipeline/src/dashboards.js
+++ b/new-pipeline/src/dashboards.js
@@ -1085,20 +1085,19 @@ function getDescriptionLink(metric, channel, description) {
 }
 
 function useCounterLink(metric, channel, description) {
-  var metricUrl = buildDictionaryURL(metric, channel, description);
-  //Hide use counter link if not applicable.
-  if (metric.startsWith("USE_COUNTER") !== true) {
-    $(".use-counter-link")
-    .hide();
-  }
-
   //Show correct use counter link based on group selection.
   if (metric.startsWith("USE_COUNTER") === true) {
     metricSplit = metric.split("_");
-    group = metricSplit[2];
-    useCounterLink = "http://georgf.github.io/usecounters/#kind=page&group=" + group + "&channel=beta&version=60";
-    $(".use-counter-link > a").attr('href', useCounterLink);
-    $(".use-counter-link")
-      .show();
+    var group = metricSplit[2];
+    var useCounterLink = $("<a>", {
+      href: "http://georgf.github.io/usecounters/#kind=page&group=" + group + "&channel=beta&version=60",
+      target: "_blank",
+      css: {
+        color: "black",
+      },
+      "aria-hidden": "true",
+    });
+    useCounterLink.text("View in use counter dashboard.");
   }
+  return useCounterLink;
 }

--- a/new-pipeline/src/dashboards.js
+++ b/new-pipeline/src/dashboards.js
@@ -1085,13 +1085,11 @@ function getDescriptionLink(metric, channel, description) {
 }
 
 function getUseCounterLink(metric, channel, description) {
-  //Show correct use counter link based on group selection.
   var metricUrl = buildDictionaryURL(metric, channel, description);
   if (metric.startsWith("USE_COUNTER") !== true) {
-    $(".use-counter-link")
-    .hide();
+    $(".use-counter-link").text(""); // Clear use counter link;
   }
-
+  //Show correct use counter link based on group selection.
   else {
     metricSplit = metric.split("_");
     var group = metricSplit[2];
@@ -1100,6 +1098,5 @@ function getUseCounterLink(metric, channel, description) {
       target: "_blank",
     });
     useCounterLink.text("View in use counter dashboard.");
-    return useCounterLink;
   }
 }

--- a/new-pipeline/src/dashboards.js
+++ b/new-pipeline/src/dashboards.js
@@ -1084,7 +1084,7 @@ function getDescriptionLink(metric, channel, description) {
   return link;
 }
 
-function showUseCounterLink(metric, channel, description) {
+function getUseCounterLink(metric, channel, description) {
   //Show correct use counter link based on group selection.
   var metricUrl = buildDictionaryURL(metric, channel, description);
   if (metric.startsWith("USE_COUNTER") !== true) {
@@ -1100,6 +1100,6 @@ function showUseCounterLink(metric, channel, description) {
       target: "_blank",
     });
     useCounterLink.text("View in use counter dashboard.");
+    return useCounterLink;
   }
-  return useCounterLink;
 }

--- a/new-pipeline/src/dashboards.js
+++ b/new-pipeline/src/dashboards.js
@@ -1085,13 +1085,12 @@ function getDescriptionLink(metric, channel, description) {
 }
 
 function getUseCounterLink(metric, channel, description) {
-  var measure = metric;
-  if (measure.startsWith("USE_COUNTER") !== true) {
+  if (metric.startsWith("USE_COUNTER") !== true) {
     return null;
   }
   else {
-    measureSplit = measure.split("_");
-    var group = measureSplit[2];
+    metricSplit = metric.split("_");
+    var group = metricSplit[2];
     var useCounterLink = $("<a>", {
       href: "http://georgf.github.io/usecounters/#kind=page&group=" + group + "&channel=beta&version=60",
       target: "_blank",

--- a/new-pipeline/src/dashboards.js
+++ b/new-pipeline/src/dashboards.js
@@ -1081,6 +1081,7 @@ function getDescriptionLink(metric, channel, description) {
       class: "btn btn-outline-primary fa fa-info-circle",
     }).text(" More details"));
   }
+  
   return link;
 }
 

--- a/new-pipeline/src/dashboards.js
+++ b/new-pipeline/src/dashboards.js
@@ -1099,4 +1099,5 @@ function getUseCounterLink(metric, channel, description) {
     });
     useCounterLink.text("View in use counter dashboard.");
   }
+  return useCounterLink;
 }

--- a/new-pipeline/src/dashboards.js
+++ b/new-pipeline/src/dashboards.js
@@ -1081,7 +1081,6 @@ function getDescriptionLink(metric, channel, description) {
       class: "btn btn-outline-primary fa fa-info-circle",
     }).text(" More details"));
   }
-  
   return link;
 }
 
@@ -1092,10 +1091,16 @@ function getUseCounterLink(metric, channel, description) {
   }
   //Show correct use counter link based on group selection.
   var metricSplit = metric.split("_");
+  if (metricSplit.length < 3) {
+    return null;
+  }
   var group = metricSplit[2];
   var useCounterLink = $("<a>", {
-    href: "http://georgf.github.io/usecounters/#kind=page&group=" + group + "&channel=beta&version=60",
+    href: "http://georgf.github.io/usecounters/#kind=page&group=" + group + "&channel=beta",
     target: "_blank",
+    css: {
+      color: "black",
+    },
   });
   useCounterLink.append($("<i>", {
     class: "btn btn-outline-primary fa fa-info-circle",

--- a/new-pipeline/src/dashboards.js
+++ b/new-pipeline/src/dashboards.js
@@ -1085,19 +1085,19 @@ function getDescriptionLink(metric, channel, description) {
 }
 
 function getUseCounterLink(metric, channel, description) {
-  if (metric.startsWith("USE_COUNTER") !== true) {
-    return null;
+  var metricUrl = buildDictionaryURL(metric, channel, description);
+  if (!metric.startsWith("USE_COUNTER2")) {
+    return null; // Clear use counter link;
   }
-  else {
-    metricSplit = metric.split("_");
-    var group = metricSplit[2];
-    var useCounterLink = $("<a>", {
-      href: "http://georgf.github.io/usecounters/#kind=page&group=" + group + "&channel=beta&version=60",
-      target: "_blank",
-    });
-    useCounterLink.append($("<i>", {
-      class: "btn btn-outline-primary fa fa-info-circle",
-    }).text(" View in use counter dashboard."));
-    return useCounterLink;
-  }
+  //Show correct use counter link based on group selection.
+  var metricSplit = metric.split("_");
+  var group = metricSplit[2];
+  var useCounterLink = $("<a>", {
+    href: "http://georgf.github.io/usecounters/#kind=page&group=" + group + "&channel=beta&version=60",
+    target: "_blank",
+  });
+  useCounterLink.append($("<i>", {
+    class: "btn btn-outline-primary fa fa-info-circle",
+  }).text(" View in use counter dashboard."));
+  return useCounterLink;
 }

--- a/new-pipeline/src/dashboards.js
+++ b/new-pipeline/src/dashboards.js
@@ -1095,7 +1095,7 @@ function getUseCounterLink(metric, channel, description) {
       href: "http://georgf.github.io/usecounters/#kind=page&group=" + group + "&channel=beta&version=60",
       target: "_blank",
     });
-    useCounterLink.append($"<i>", {
+    useCounterLink.append($("<i>", {
       class: "btn btn-outline-primary fa fa-info-circle",
     }).text(" View in use counter dashboard."));
   else {

--- a/new-pipeline/src/dashboards.js
+++ b/new-pipeline/src/dashboards.js
@@ -701,7 +701,7 @@ function getHumanReadableOptions(filterName, options) {
     return options.map(function (option) {
       return option !== null ? [option, option.replace("aurora", "dev edition").replace("/", " ")] : null;
     });
-		   
+
   }
   return options.map(function (option) {
     return [option, option];
@@ -1080,6 +1080,23 @@ function getDescriptionLink(metric, channel, description) {
     link.append($("<i>", {
       class: "btn btn-outline-primary fa fa-info-circle",
     }).text(" More details"));
+  }
+
+  //Hide use counter link if not applicable.
+  if (metric.startsWith("USE_COUNTER") !== true) {
+    $(".use-counter-link")
+    .hide();
+  }
+
+  //Show correct use counter link based on group selection.
+  if (metric.startsWith("USE_COUNTER") === true) {
+    metricSplit = metric.split("_");
+    group = metricSplit[2];
+    useCounterLink = "http://georgf.github.io/usecounters/#kind=page&group=" + group + "&channel=beta&version=60";
+    $(".use-counter-link > a").attr('href', useCounterLink);
+    $(".use-counter-link")
+      .show();
+    console.log(useCounterLink);
   }
 
   return link;

--- a/new-pipeline/src/dashboards.js
+++ b/new-pipeline/src/dashboards.js
@@ -1084,7 +1084,7 @@ function getDescriptionLink(metric, channel, description) {
   return link;
 }
 
-function useCounterLink(metric, channel, description) {
+function showUseCounterLink(metric, channel, description) {
   //Show correct use counter link based on group selection.
   var metricUrl = buildDictionaryURL(metric, channel, description);
   if (metric.startsWith("USE_COUNTER") === true) {

--- a/new-pipeline/src/dashboards.js
+++ b/new-pipeline/src/dashboards.js
@@ -1089,7 +1089,7 @@ function showUseCounterLink(metric, channel, description) {
   var metricUrl = buildDictionaryURL(metric, channel, description);
   if (metric.startsWith("USE_COUNTER") !== true) {
     $(".use-counter-link")
-    .text("");
+    .hide();
   }
 
   else {

--- a/new-pipeline/src/dashboards.js
+++ b/new-pipeline/src/dashboards.js
@@ -701,8 +701,8 @@ function getHumanReadableOptions(filterName, options) {
     return options.map(function (option) {
       return option !== null ? [option, option.replace("aurora", "dev edition").replace("/", " ")] : null;
     });
-
   }
+  
   return options.map(function (option) {
     return [option, option];
   });
@@ -1096,7 +1096,6 @@ function getDescriptionLink(metric, channel, description) {
     $(".use-counter-link > a").attr('href', useCounterLink);
     $(".use-counter-link")
       .show();
-    console.log(useCounterLink);
   }
 
   return link;

--- a/new-pipeline/src/dashboards.js
+++ b/new-pipeline/src/dashboards.js
@@ -1086,6 +1086,7 @@ function getDescriptionLink(metric, channel, description) {
 
 function useCounterLink(metric, channel, description) {
   //Show correct use counter link based on group selection.
+  var metricUrl = buildDictionaryURL(metric, channel, description);
   if (metric.startsWith("USE_COUNTER") === true) {
     metricSplit = metric.split("_");
     var group = metricSplit[2];

--- a/new-pipeline/src/dist.js
+++ b/new-pipeline/src/dist.js
@@ -862,14 +862,6 @@ function displayHistograms(histogramsList, dates, useTable, cumulative, trim) {
     });
   }
 
-  var useCounterLink = getUseCounterLink(metric, channel, description);
-  if (!useCounterLink) {
-    $('#use-counter-link').text("");
-  }
-  else {
-    $('#use-counter-link').html(useCounterLink);
-  }
-
   if (histogramsList.length > 0 && histogramsList[0].histograms.length > 0) {
     // Set the histogram caption to the histogram description
     var description = histogramsList[0].histograms[0].description
@@ -877,6 +869,7 @@ function displayHistograms(histogramsList, dates, useTable, cumulative, trim) {
     var channel = $("#channel-version").val().split("/")[0]
     var desc = getDescription(metric, channel, description);
     var link = getDescriptionLink(metric, channel, description);
+    var useCounterLink = getUseCounterLink(metric, channel, description);
     $('#dist-caption-text').html(desc);
     $('#dist-caption-link').html(link);
     $('#use-counter-link').html(useCounterLink);
@@ -885,6 +878,13 @@ function displayHistograms(histogramsList, dates, useTable, cumulative, trim) {
     $('#dist-caption-text').text(""); // Clear the histogram caption
     $('#dist-caption-link').text(""); // Clear the histogram link
     $('#use-counter-link').text(""); // Clear use counter link
+  }
+
+  if (!useCounterLink) {
+    $('#use-counter-link').text("");
+  }
+  else {
+    $('#use-counter-link').html(useCounterLink);
   }
 
   if (histogramsList.length <= 1) { // Only one histograms set

--- a/new-pipeline/src/dist.js
+++ b/new-pipeline/src/dist.js
@@ -869,7 +869,7 @@ function displayHistograms(histogramsList, dates, useTable, cumulative, trim) {
     var channel = $("#channel-version").val().split("/")[0]
     var desc = getDescription(metric, channel, description);
     var link = getDescriptionLink(metric, channel, description);
-    var useCounter = showUseCounterLink(metric, channel, description);
+    var useCounterLink = showUseCounterLink(metric, channel, description);
     $('#dist-caption-text').html(desc);
     $('#dist-caption-link').html(link);
     $('#use-counter-link').html(useCounterLink);

--- a/new-pipeline/src/dist.js
+++ b/new-pipeline/src/dist.js
@@ -862,12 +862,12 @@ function displayHistograms(histogramsList, dates, useTable, cumulative, trim) {
     });
   }
 
-  if (getUseCounterLink() returns null) {
-    $('use-counter-link').text("");
-  }
   var useCounterLink = getUseCounterLink(metric, channel, description);
+  if (!useCounterLink) {
+    $('#use-counter-link').text("");
+  }
   else {
-    $('use-counter-link').html(useCounterLink);
+    $('#use-counter-link').html(useCounterLink);
   }
 
   if (histogramsList.length > 0 && histogramsList[0].histograms.length > 0) {

--- a/new-pipeline/src/dist.js
+++ b/new-pipeline/src/dist.js
@@ -884,6 +884,7 @@ function displayHistograms(histogramsList, dates, useTable, cumulative, trim) {
   } else {
     $('#dist-caption-text').text(""); // Clear the histogram caption
     $('#dist-caption-link').text(""); // Clear the histogram link
+    $('.use-counter-link').text(""); // Clear use counter link
   }
 
   if (histogramsList.length <= 1) { // Only one histograms set

--- a/new-pipeline/src/dist.js
+++ b/new-pipeline/src/dist.js
@@ -876,8 +876,11 @@ function displayHistograms(histogramsList, dates, useTable, cumulative, trim) {
     var channel = $("#channel-version").val().split("/")[0]
     var desc = getDescription(metric, channel, description);
     var link = getDescriptionLink(metric, channel, description);
+    var use-counter= useCounterLink(metric, channel, description);
     $('#dist-caption-text').html(desc);
     $('#dist-caption-link').html(link);
+    $('.use-counter-link').html(use-counter);
+
   } else {
     $('#dist-caption-text').text(""); // Clear the histogram caption
     $('#dist-caption-link').text(""); // Clear the histogram link

--- a/new-pipeline/src/dist.js
+++ b/new-pipeline/src/dist.js
@@ -869,7 +869,7 @@ function displayHistograms(histogramsList, dates, useTable, cumulative, trim) {
     var channel = $("#channel-version").val().split("/")[0]
     var desc = getDescription(metric, channel, description);
     var link = getDescriptionLink(metric, channel, description);
-    var useCounterLink = showUseCounterLink(metric, channel, description);
+    var useCounterLink = getUseCounterLink(metric, channel, description);
     $('#dist-caption-text').html(desc);
     $('#dist-caption-link').html(link);
     $('#use-counter-link').html(useCounterLink);

--- a/new-pipeline/src/dist.js
+++ b/new-pipeline/src/dist.js
@@ -869,7 +869,7 @@ function displayHistograms(histogramsList, dates, useTable, cumulative, trim) {
     var channel = $("#channel-version").val().split("/")[0]
     var desc = getDescription(metric, channel, description);
     var link = getDescriptionLink(metric, channel, description);
-    var useCounter = useCounterLink(metric, channel, description);
+    var useCounter = showUseCounterLink(metric, channel, description);
     $('#dist-caption-text').html(desc);
     $('#dist-caption-link').html(link);
     $('#use-counter-link').html(useCounterLink);

--- a/new-pipeline/src/dist.js
+++ b/new-pipeline/src/dist.js
@@ -869,22 +869,20 @@ function displayHistograms(histogramsList, dates, useTable, cumulative, trim) {
     var channel = $("#channel-version").val().split("/")[0]
     var desc = getDescription(metric, channel, description);
     var link = getDescriptionLink(metric, channel, description);
-    var useCounterLink = getUseCounterLink(metric, channel, description);
-    $('#dist-caption-text').html(desc);
+    if (metric != desc) {
+      $('#dist-caption-text').html(desc);
+    } else {
+      $('#dist-caption-text').text("");
+    }
     $('#dist-caption-link').html(link);
+
+    var useCounterLink = getUseCounterLink(metric, channel, description);
     $('#use-counter-link').html(useCounterLink);
 
   } else {
     $('#dist-caption-text').text(""); // Clear the histogram caption
     $('#dist-caption-link').text(""); // Clear the histogram link
-    $('#use-counter-link').text(""); // Clear use counter link
-  }
-
-  if (!useCounterLink) {
-    $('#use-counter-link').text("");
-  }
-  else {
-    $('#use-counter-link').html(useCounterLink);
+    $('#use-counter-link').text(""); // Clear the use counter link
   }
 
   if (histogramsList.length <= 1) { // Only one histograms set

--- a/new-pipeline/src/dist.js
+++ b/new-pipeline/src/dist.js
@@ -869,12 +869,15 @@ function displayHistograms(histogramsList, dates, useTable, cumulative, trim) {
     var channel = $("#channel-version").val().split("/")[0]
     var desc = getDescription(metric, channel, description);
     var link = getDescriptionLink(metric, channel, description);
+    var useCounter = useCounterLink(metric, channel, description);
     $('#dist-caption-text').html(desc);
     $('#dist-caption-link').html(link);
+    $('#use-counter-link').html(useCounterLink);
 
   } else {
     $('#dist-caption-text').text(""); // Clear the histogram caption
     $('#dist-caption-link').text(""); // Clear the histogram link
+    $('#use-counter-link').text(""); // Clear use counter link
   }
 
   if (histogramsList.length <= 1) { // Only one histograms set

--- a/new-pipeline/src/dist.js
+++ b/new-pipeline/src/dist.js
@@ -862,6 +862,14 @@ function displayHistograms(histogramsList, dates, useTable, cumulative, trim) {
     });
   }
 
+  if (getUseCounterLink() returns null) {
+    $('use-counter-link').text("");
+  }
+  var useCounterLink = getUseCounterLink(metric, channel, description);
+  else {
+    $('use-counter-link').html(useCounterLink);
+  }
+
   if (histogramsList.length > 0 && histogramsList[0].histograms.length > 0) {
     // Set the histogram caption to the histogram description
     var description = histogramsList[0].histograms[0].description
@@ -869,7 +877,6 @@ function displayHistograms(histogramsList, dates, useTable, cumulative, trim) {
     var channel = $("#channel-version").val().split("/")[0]
     var desc = getDescription(metric, channel, description);
     var link = getDescriptionLink(metric, channel, description);
-    var useCounterLink = getUseCounterLink(metric, channel, description);
     $('#dist-caption-text').html(desc);
     $('#dist-caption-link').html(link);
     $('#use-counter-link').html(useCounterLink);

--- a/new-pipeline/src/dist.js
+++ b/new-pipeline/src/dist.js
@@ -876,10 +876,10 @@ function displayHistograms(histogramsList, dates, useTable, cumulative, trim) {
     var channel = $("#channel-version").val().split("/")[0]
     var desc = getDescription(metric, channel, description);
     var link = getDescriptionLink(metric, channel, description);
-    var use-counter= useCounterLink(metric, channel, description);
+    var useCounter= useCounterLink(metric, channel, description);
     $('#dist-caption-text').html(desc);
     $('#dist-caption-link').html(link);
-    $('.use-counter-link').html(use-counter);
+    $('.use-counter-link').html(useCounter);
 
   } else {
     $('#dist-caption-text').text(""); // Clear the histogram caption

--- a/new-pipeline/src/evo.js
+++ b/new-pipeline/src/evo.js
@@ -331,7 +331,6 @@ $(function () {
                 $("#evo-caption-text").html(description);
               } else {
                 $('#evo-caption-text').text("");
-                $('#use-counter-link').text("");
               }
               $('#evo-caption-link').html(link);
               $("#selected-key")

--- a/new-pipeline/src/evo.js
+++ b/new-pipeline/src/evo.js
@@ -328,8 +328,10 @@ $(function () {
               $("#sample-counts-title").text(metric + " sample counts");
               if (metric != description) {
                 $("#evo-caption-text").html(description);
+                $("#use-counter-link").html(useCounterLink);
               } else {
                 $('#evo-caption-text').text("");
+                $('#use-counter-link').text("");
               }
               $('#evo-caption-link').html(link);
               $("#selected-key")

--- a/new-pipeline/src/evo.js
+++ b/new-pipeline/src/evo.js
@@ -324,7 +324,6 @@ $(function () {
               var channel = $("#max-channel-version").val().split("/")[0]
               var description = getDescription(metric, channel, evolutionDescription);
               var link = getDescriptionLink(metric, channel, description);
-              var useCounterLink = getUseCounterLink(metric, channel, description);
               $("#submissions-title").text(metric + " submissions");
               $("#sample-counts-title").text(metric + " sample counts");
               if (metric != description) {
@@ -336,6 +335,7 @@ $(function () {
               $("#selected-key")
                 .trigger("change");
               // Clear use counter link when not applicable.
+              var useCounterLink = getUseCounterLink(metric, channel, description);
               if (!useCounterLink) {
                 $('#use-counter-link').text("");
               } else {

--- a/new-pipeline/src/evo.js
+++ b/new-pipeline/src/evo.js
@@ -324,15 +324,12 @@ $(function () {
               var channel = $("#max-channel-version").val().split("/")[0]
               var description = getDescription(metric, channel, evolutionDescription);
               var link = getDescriptionLink(metric, channel, description);
-              var useCounterLink = showUseCounterLink(metric, channel, description);
               $("#submissions-title").text(metric + " submissions");
               $("#sample-counts-title").text(metric + " sample counts");
               if (metric != description) {
                 $("#evo-caption-text").html(description);
-                $("#use-counter-link").html(useCounterLink);
               } else {
                 $('#evo-caption-text').text("");
-                $('#use-counter-link').text("");
               }
               $('#evo-caption-link').html(link);
               $("#selected-key")

--- a/new-pipeline/src/evo.js
+++ b/new-pipeline/src/evo.js
@@ -324,6 +324,7 @@ $(function () {
               var channel = $("#max-channel-version").val().split("/")[0]
               var description = getDescription(metric, channel, evolutionDescription);
               var link = getDescriptionLink(metric, channel, description);
+              var useCounter = showUseCounterLink(metric, channel, description);
               $("#submissions-title").text(metric + " submissions");
               $("#sample-counts-title").text(metric + " sample counts");
               if (metric != description) {

--- a/new-pipeline/src/evo.js
+++ b/new-pipeline/src/evo.js
@@ -333,9 +333,14 @@ $(function () {
                 $('#evo-caption-text').text("");
               }
               $('#evo-caption-link').html(link);
-              $('#use-counter-link').html(useCounterLink);
               $("#selected-key")
                 .trigger("change");
+              // Clear use counter link when not applicable.
+              if (getUseCounterLink() returns null) {
+                $('#use-counter-link').text("");
+              } else {
+                $('#use-counter-link').html(useCounterLink)
+              }
             });
           });
         });

--- a/new-pipeline/src/evo.js
+++ b/new-pipeline/src/evo.js
@@ -334,6 +334,8 @@ $(function () {
               }
               $('#evo-caption-link').html(link);
               $('#use-counter-link').html(useCounterLink);
+              $('#use-counter-link')
+                .trigger('change');
               $("#selected-key")
                 .trigger("change");
             });

--- a/new-pipeline/src/evo.js
+++ b/new-pipeline/src/evo.js
@@ -324,7 +324,7 @@ $(function () {
               var channel = $("#max-channel-version").val().split("/")[0]
               var description = getDescription(metric, channel, evolutionDescription);
               var link = getDescriptionLink(metric, channel, description);
-              var useCounter = showUseCounterLink(metric, channel, description);
+              var useCounterLink = showUseCounterLink(metric, channel, description);
               $("#submissions-title").text(metric + " submissions");
               $("#sample-counts-title").text(metric + " sample counts");
               if (metric != description) {

--- a/new-pipeline/src/evo.js
+++ b/new-pipeline/src/evo.js
@@ -334,8 +334,6 @@ $(function () {
               }
               $('#evo-caption-link').html(link);
               $('#use-counter-link').html(useCounterLink);
-              $('#use-counter-link')
-                .trigger('change');
               $("#selected-key")
                 .trigger("change");
             });

--- a/new-pipeline/src/evo.js
+++ b/new-pipeline/src/evo.js
@@ -32,7 +32,7 @@ const kDefaultSelectedAggregates = [
   "95th-percentile",
 ];
 // these will be generated, but won't appear in the multiselect
-// note: some code using gMetaAggregates assumes for convenience that 
+// note: some code using gMetaAggregates assumes for convenience that
 // meta aggregate names are special and hopefully won't ever collide with
 // (dynamically generated) names of other aggregates.
 var gMetaAggregates = [
@@ -289,7 +289,7 @@ $(function () {
               multiselectSetOptions($("#selected-key"),
                 options);
               if (gInitialPageState.keys &&
-                gInitialPageState.keys.length > 0) { // Reselect previously selected key            
+                gInitialPageState.keys.length > 0) { // Reselect previously selected key
                 // Check to make sure the key can actually still be selected
                 var key = gInitialPageState.keys[0];
                 if ($("#selected-key")
@@ -326,10 +326,12 @@ $(function () {
               var channel = $("#max-channel-version").val().split("/")[0]
               var description = getDescription(metric, channel, evolutionDescription);
               var link = getDescriptionLink(metric, channel, description);
+              var use-counter= useCounterLink(metric, channel, description);
               $("#submissions-title").text(metric + " submissions");
               $("#sample-counts-title").text(metric + " sample counts");
               $("#evo-caption-text").html(description);
               $('#evo-caption-link').html(link);
+              $('.use-counter-link').html(use-counter);
               $("#selected-key")
                 .trigger("change");
             });

--- a/new-pipeline/src/evo.js
+++ b/new-pipeline/src/evo.js
@@ -324,6 +324,7 @@ $(function () {
               var channel = $("#max-channel-version").val().split("/")[0]
               var description = getDescription(metric, channel, evolutionDescription);
               var link = getDescriptionLink(metric, channel, description);
+              var useCounterLink = getUseCounterLink(metric, channel, description);
               $("#submissions-title").text(metric + " submissions");
               $("#sample-counts-title").text(metric + " sample counts");
               if (metric != description) {
@@ -332,6 +333,7 @@ $(function () {
                 $('#evo-caption-text').text("");
               }
               $('#evo-caption-link').html(link);
+              $('#use-counter-link').html(useCounterLink);
               $("#selected-key")
                 .trigger("change");
             });

--- a/new-pipeline/src/evo.js
+++ b/new-pipeline/src/evo.js
@@ -326,12 +326,12 @@ $(function () {
               var channel = $("#max-channel-version").val().split("/")[0]
               var description = getDescription(metric, channel, evolutionDescription);
               var link = getDescriptionLink(metric, channel, description);
-              var use-counter= useCounterLink(metric, channel, description);
+              var useCounter= useCounterLink(metric, channel, description);
               $("#submissions-title").text(metric + " submissions");
               $("#sample-counts-title").text(metric + " sample counts");
               $("#evo-caption-text").html(description);
               $('#evo-caption-link').html(link);
-              $('.use-counter-link').html(use-counter);
+              $('.use-counter-link').html(useCounter);
               $("#selected-key")
                 .trigger("change");
             });

--- a/new-pipeline/src/evo.js
+++ b/new-pipeline/src/evo.js
@@ -331,15 +331,16 @@ $(function () {
                 $("#evo-caption-text").html(description);
               } else {
                 $('#evo-caption-text').text("");
+                $('#use-counter-link').text("");
               }
               $('#evo-caption-link').html(link);
               $("#selected-key")
                 .trigger("change");
               // Clear use counter link when not applicable.
-              if (getUseCounterLink() returns null) {
+              if (!useCounterLink) {
                 $('#use-counter-link').text("");
               } else {
-                $('#use-counter-link').html(useCounterLink)
+                $('#use-counter-link').html(useCounterLink);
               }
             });
           });

--- a/new-pipeline/style/dashboards.css
+++ b/new-pipeline/style/dashboards.css
@@ -123,7 +123,7 @@
 .mg-marker-text { font-size: 12px !important; }
 .mg-markers line { stroke-width: 2px !important; }
 
-.caption-div {
+.caption-div, .use-counter-div {
   display: flex;
   justify-content: center;
   align-items: center;
@@ -139,7 +139,7 @@
   text-align: center;
 }
 
-#dist-caption-link, #evo-caption-link {
+#dist-caption-link, #evo-caption-link, #use-counter-link {
   color : black;
   display: inline-block;
 }


### PR DESCRIPTION
Hey @georgf, I think I've gotten pretty close here; the branching seems to be working well now and I think this is the placement you were thinking of (?). Correct me if I'm wrong!

I still can't get the link to disappear when the probe switches to a "non-use counter" measure. Upon refresh or if you switch views, the link will go away, but not immediately. Thoughts...?

You can see my changes live [here](https://ecomerford.github.io/telemetry-dashboard/).

Thanks!