### PR TITLE
Fixes #395 - Use correct bucket labels for categorical evolutions

### DIFF
--- a/new-pipeline/src/dashboards.js
+++ b/new-pipeline/src/dashboards.js
@@ -718,7 +718,7 @@ function getHumanReadableBucketOptions(kind, buckets) {
       ];
     });
   } else if (kind == "categorical") {
-    return buckets.map( (b, i) => [i.toString(), b] )
+    return buckets.map( (b, i) => ["bucket-" + i.toString(), b] )
   }
 
   return buckets.map(function (start) {

--- a/new-pipeline/src/evo.js
+++ b/new-pipeline/src/evo.js
@@ -394,13 +394,10 @@ var gLoadedAggregatesFromState = false;
 function updateAggregates(kind, buckets) {
   gCurrentKind = kind;
   let newAggregates;
-  if (kind === "enumerated") {
+  if (kind === "enumerated" || kind === "categorical") {
     newAggregates = getHumanReadableBucketOptions(kind, buckets);
     multiselectSetOptions($("#aggregates"), newAggregates, [newAggregates[0][0]]);
-  } else if(kind == "categorical") {
-    newAggregates = buckets.map((r, i) => {return [i.toString(), r]})
-    multiselectSetOptions($("#aggregates"), newAggregates, [newAggregates[0][0]]);
-  }  else if (kind === "boolean" || kind === "flag") {
+  } else if (kind === "boolean" || kind === "flag") {
     newAggregates = getHumanReadableBucketOptions(kind, buckets);
     multiselectSetOptions($("#aggregates"), newAggregates, [newAggregates[0][0]]);
 


### PR DESCRIPTION
In investigating the stalled #504 I hit upon this solution. It was a mismatch between the three (yes, three) places that depended on the bucket labels being appropriately named. This standardizes on "bucket-n" naming.