### PR TITLE
Fix search results display of probes not yet on release

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,16 +40,20 @@
                         SQL Portal <span class="fa fa-lock"></span>
                         <div class="dashboard-description">View dashboards &amp; run SQL queries.</div>
                     </a>
-                    <a class="list-group-item" href="https://moz-experiments-viewer.herokuapp.com/">
-                        Experiments Viewer <span class="fa fa-lock"></span>
-                        <div class="dashboard-description">See the impact different experiments have.</div>
-                    </a>
                     <a class="list-group-item" href="https://data-missioncontrol.dev.mozaws.net/">
                       Mission Control <div class="dashboard-description">View key Firefox quality measures in near-realtime.</div>
                     </a>
                     <a class="list-group-item" href="https://analysis.telemetry.mozilla.org/">
                         Analysis Portal <span class="fa fa-lock"></span>
                         <div class="dashboard-description">Analyze telemetry data with Spark.</div>
+                    </a>
+                    <a class="list-group-item" href="https://moz-experiments-viewer.herokuapp.com/">
+                        Experiments Viewer <span class="fa fa-lock"></span>
+                        <div class="dashboard-description">See the impact different experiments have.</div>
+                    </a>
+                    <a class="list-group-item" href="https://experimenter.services.mozilla.com/">
+                        Experimenter <span class="fa fa-lock"></span>
+                        <div class="dashboard-description">Create, monitor &amp; review Shield studies.</div>
                     </a>
                 </div>
                 <h3><i class="fa fa-book" aria-hidden="true"></i> Documentation</h3>

--- a/index.html
+++ b/index.html
@@ -47,8 +47,8 @@
                         Analysis Portal <span class="fa fa-lock"></span>
                         <div class="dashboard-description">Analyze telemetry data with Spark.</div>
                     </a>
-                    <a class="list-group-item" href="https://moz-experiments-viewer.herokuapp.com/">
-                        Experiments Viewer <span class="fa fa-lock"></span>
+                    <a class="list-group-item" href="https://firefox-test-tube.herokuapp.com/">
+                        Test Tube <span class="fa fa-lock"></span>
                         <div class="dashboard-description">See the impact different experiments have.</div>
                     </a>
                     <a class="list-group-item" href="https://experimenter.services.mozilla.com/">

--- a/index.html
+++ b/index.html
@@ -47,13 +47,13 @@
                         Analysis Portal <span class="fa fa-lock"></span>
                         <div class="dashboard-description">Analyze telemetry data with Spark.</div>
                     </a>
-                    <a class="list-group-item" href="https://firefox-test-tube.herokuapp.com/">
-                        Test Tube <span class="fa fa-lock"></span>
-                        <div class="dashboard-description">See the impact different experiments have.</div>
-                    </a>
                     <a class="list-group-item" href="https://experimenter.services.mozilla.com/">
                         Experimenter <span class="fa fa-lock"></span>
                         <div class="dashboard-description">Create, monitor &amp; review Shield studies.</div>
+                    </a>
+                    <a class="list-group-item" href="https://firefox-test-tube.herokuapp.com/">
+                        Test Tube <span class="fa fa-lock"></span>
+                        <div class="dashboard-description">See the impact different experiments have.</div>
                     </a>
                 </div>
                 <h3><i class="fa fa-book" aria-hidden="true"></i> Documentation</h3>

--- a/probe-dictionary/explore.js
+++ b/probe-dictionary/explore.js
@@ -431,24 +431,26 @@ function shortVersion(v) {
   return v.split(".")[0];
 }
 
-function friendlyRecordingRange(firstVersion, expiry) {
-  if (expiry == "never") {
-    return `from ${firstVersion}`;
-  }
-  return `${firstVersion} to ${parseInt(shortVersion(expiry)) - 1}`;
-}
-
-function friendlyRecordingRangeForState(state, channel) {
-  const firstVersion = getVersionRange(channel, state["revisions"]).first;
-  const expiry = state.expiry_version;
-  return friendlyRecordingRange(firstVersion, expiry);
-}
-
 function friendlyRecordingRangeForHistory(history, channel) {
   const last = array => array[array.length - 1];
-  const firstVersion = getVersionRange(channel, history[0]["revisions"]).first;
+
   const expiry = last(history).expiry_version;
-  return friendlyRecordingRange(firstVersion, expiry);
+  const latestVersion = Math.max.apply(null, Object.keys(gChannelInfo[channel].versions));
+  const firstVersion = getVersionRange(channel, last(history).revisions).first;
+  let lastVersion = getVersionRange(channel, history[0].revisions).last;
+
+  if (expiry == "never" && (lastVersion >= latestVersion)) {
+    return `from ${firstVersion}`;
+  }
+
+  if (expiry != "never") {
+    const expiryVersion = parseInt(shortVersion(expiry));
+    if (lastVersion >= expiryVersion) {
+      lastVersion = expiryVersion - 1;
+    }
+  }
+
+  return `${firstVersion} to ${lastVersion}`;
 }
 
 function renderMeasurements(measurements) {

--- a/probe-dictionary/explore.js
+++ b/probe-dictionary/explore.js
@@ -431,10 +431,10 @@ function shortVersion(v) {
   return v.split(".")[0];
 }
 
-function friendlyRecordingRangeForHistory(history, channel) {
+function friendlyRecordingRangeForHistory(history, channel, filterPrerelease) {
   const last = array => array[array.length - 1];
 
-  if (channel == "release") {
+  if ((channel == "release") && filterPrerelease) {
     history = history.filter(h => h.optout);
   }
 
@@ -471,7 +471,7 @@ function renderMeasurements(measurements) {
     ["name", (d, h, c) => d.name],
     ["type", (d, h, c) => d.type],
     ["population", (d, h, c) => h.optout ? "release" : "prerelease"],
-    ["recorded", (d, h, c, history) => friendlyRecordingRangeForHistory(history, c)],
+    ["recorded", (d, h, c, history) => friendlyRecordingRangeForHistory(history, c, false)],
     // TODO: overflow should cut off
     ["description", (d, h, c) => escapeHtml(h.description)],
   ];
@@ -853,7 +853,7 @@ function showDetailViewForId(probeId, channel=$("#select_channel").val()) {
     if ((!history[0].optout && (ch == "release")) || (ch == "aurora")) {
       continue;
     }
-    rangeText.push(`${ch} ${friendlyRecordingRangeForHistory(history, ch)}`);
+    rangeText.push(`${ch} ${friendlyRecordingRangeForHistory(history, ch, true)}`);
   }
   $('#detail-recording-range').html(rangeText.join("<br/>"));
 

--- a/probe-dictionary/explore.js
+++ b/probe-dictionary/explore.js
@@ -431,13 +431,25 @@ function shortVersion(v) {
   return v.split(".")[0];
 }
 
+/**
+ * Return a human readable description of from when to when a probe is recorded.
+ * This can return "never", "from X to Y" or "from X" for non-expiring probes.
+ *
+ * @param history The history array of a probe for a channel.
+ * @param channel The Firefox channel this history is for.
+ * @param filterPrerelease Whether to filter out prerelease probes on the release channel.
+ */
 function friendlyRecordingRangeForHistory(history, channel, filterPrerelease) {
   const last = array => array[array.length - 1];
 
+  // Optionally filter out prerelease probes on the release channel.
+  // This is used for the detail view, but not for the search results view.
   if ((channel == "release") && filterPrerelease) {
     history = history.filter(h => h.optout);
   }
 
+  // The filtering might have left us with an empty recording history.
+  // This means we never recorded anything on this channel.
   if (history.length == 0) {
     return "never";
   }

--- a/probe-dictionary/explore.js
+++ b/probe-dictionary/explore.js
@@ -434,6 +434,14 @@ function shortVersion(v) {
 function friendlyRecordingRangeForHistory(history, channel) {
   const last = array => array[array.length - 1];
 
+  if (channel == "release") {
+    history = history.filter(h => h.optout);
+  }
+
+  if (history.length == 0) {
+    return "never";
+  }
+
   const expiry = last(history).expiry_version;
   const latestVersion = Math.max.apply(null, Object.keys(gChannelInfo[channel].versions));
   const firstVersion = getVersionRange(channel, last(history).revisions).first;


### PR DESCRIPTION
When initially adding the ability to search in "any" channel to the probe dictionary, i used the hack of always only showing the release channel search results.
This breaks when a probe state hasn't propagated yet to release, see #536.

This fixes how we render search results by always showing the “best
availabe” history from “release”, “beta” or “nightly” for each probe.
That avoids hiding probes that haven’t reached the release channel yet
when searching with channel “any”.

See [here](https://georgf.github.io/telemetry-dashboard/probe-dictionary/?search=docgroup) for a live link of the changes.