### PR TITLE
Tweak error message CSS

### DIFF
--- a/new-pipeline/style/dashboards.css
+++ b/new-pipeline/style/dashboards.css
@@ -148,8 +148,9 @@
 .error-msg {
   border: 2px solid #C13832; /* Mozilla Red */
   background-color: #D7D3C8; /* Mozilla Sand */
-  padding: 1em;
+  padding: 0.5em;
   color: #4D4E53; /* Mozilla charcoal */
+  margin-bottom: 1em;
 }
 .error-msg:empty {
   display: none;


### PR DESCRIPTION
Tweak the CSS of the error message a bit:
* Add a bit of margin between the error message and the tab elements.
* Also use a bit less padding in the error message as it’s more than
needed.

You can see it live [here](https://georgf.github.io/telemetry-dashboard/new-pipeline/dist.html).