### PR TITLE
Update link to the graphics telemetry dashboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,7 +113,7 @@
                     <a class="list-group-item" href="http://alerts.telemetry.mozilla.org/">
                         Telemetry Alerts <div class="dashboard-description">Set up email alerts for significant performance changes.</div>
                     </a>
-                    <a class="list-group-item" href="https://people.mozilla.org/~danderson/moz-gfx-telemetry/www/">
+                    <a class="list-group-item" href="https://firefoxgraphics.github.io/telemetry/">
                         Graphics Telemetry <div class="dashboard-description">View percentage breakdowns for various graphics features.</div>
                     </a>
                     <a class="list-group-item" href="https://georgf.github.io/usecounters/index.html">


### PR DESCRIPTION
The dashboard has moved multiple times since `people.mozilla.org` was decommissioned and is now hosted at `firefoxgraphics.github.io/telemetry`.