### PR TITLE
First Auth0 Prototype for Measurement Dashboards

### DIFF
--- a/new-pipeline/dist.html
+++ b/new-pipeline/dist.html
@@ -21,6 +21,8 @@
 <body>
     <div class="container-fluid">
         <header>
+            <form id="auth-form" class="navbar-form inline pull-right btn-group">
+            </form>
             <form class="navbar-form inline pull-right btn-group">
                 <a href="#" class="btn btn-default permalink-button" title="Get Shortlink"><i class="fa fa-link"></i> Get Shortlink</a>
                 <input type="text" class="permalink-text input btn btn-default">
@@ -229,6 +231,7 @@
     <script src="../v2/telemetry.js"></script>
     <script src="src/dashboards.js"></script>
     <script src="src/dist.js"></script>
+    <script src="src/auth.js"></script>
 
     <script src="../analytics/analytics.js"></script>
 </body>

--- a/new-pipeline/evo.html
+++ b/new-pipeline/evo.html
@@ -19,6 +19,8 @@
 <body>
     <div class="container-fluid">
         <header>
+            <form id="auth-form" class="navbar-form inline pull-right btn-group">
+            </form>
             <form class="navbar-form inline pull-right btn-group">
                 <a href="#" class="btn btn-default permalink-button" title="Get Shortlink"><i class="fa fa-link"></i> Get Shortlink</a>
                 <input type="text" class="permalink-text input btn btn-default">
@@ -128,6 +130,7 @@
     <script src="../v2/telemetry.js"></script>
     <script src="src/dashboards.js"></script>
     <script src="src/evo.js"></script>
+    <script src="src/auth.js"></script>
 
     <script src="../analytics/analytics.js"></script>
 </body>

--- a/new-pipeline/src/auth.js
+++ b/new-pipeline/src/auth.js
@@ -53,9 +53,9 @@ function constructLoginUrl() {
 
 function constructLogoutUrl() {
   let currentUrl = new URL(window.location.href);
-  // Discard the hash in case there's an access_token in it. The dashboard
-  // will restore state from Cookie.
-  currentUrl.hash = "";
+  // Reset the hash to the default measurement on logout since we don't want
+  // lingering release-channel state to restart the login flow.
+  currentUrl.hash = "measure=GC_MS";
 
   let logoutUrl = new URL(AUTH0_ORIGIN + "v2/logout");
   logoutUrl.searchParams.append("returnTo", currentUrl.toString());

--- a/new-pipeline/src/auth.js
+++ b/new-pipeline/src/auth.js
@@ -20,9 +20,9 @@ function randomString(length) {
   return result.join('');
 }
 
-const AUTH0_ORIGIN = "https://chutten.auth0.com/";
-const AGGREGATES_APP_CLIENT_ID = "v427CBip66hS4q2mtJeZJWiYK1aEvQTK";
-const AGGREGATES_API_AUDIENCE_ID = "aggregates.telemetry.mozilla.org";
+const AUTH0_ORIGIN = "https://auth.mozilla.com/";
+const AGGREGATES_APP_CLIENT_ID = "kj04FIzGyg9CjSGphdTelwezVHHV1HVc";
+const AGGREGATES_API_AUDIENCE_ID = "https://aggregates.telemetry.mozilla.org/";
 const AGGREGATES_API_SCOPE = "read:aggregates";
 function constructLoginUrl() {
 

--- a/new-pipeline/src/auth.js
+++ b/new-pipeline/src/auth.js
@@ -1,0 +1,118 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function () {
+
+// The state we used when asking for the token. A 16-character random string.
+// We could use the actual app state if we wanted to.
+let gRequestState;
+
+/* Copied with implicit license from Auth0 docs: randomString */
+function randomString(length) {
+  var bytes = new Uint8Array(length);
+  var random = window.crypto.getRandomValues(bytes);
+  var result = [];
+  var charset = "0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._~";
+  random.forEach(function (c) {
+    result.push(charset[c % charset.length]);
+  });
+  return result.join('');
+}
+
+const AUTH0_ORIGIN = "https://chutten.auth0.com/";
+const AGGREGATES_APP_CLIENT_ID = "v427CBip66hS4q2mtJeZJWiYK1aEvQTK";
+const AGGREGATES_API_AUDIENCE_ID = "aggregates.telemetry.mozilla.org";
+const AGGREGATES_API_SCOPE = "read:aggregates";
+function constructLoginUrl() {
+
+  gRequestState = randomString(16);
+  localStorage.setItem('gRequestState', gRequestState);
+
+  let currentUrl = new URL(window.location.href);
+  // Discard the hash in case there's an access_token in it. The dashboard
+  // will restore state from Cookie.
+  currentUrl.hash = "";
+
+  const params = {
+    scope: AGGREGATES_API_SCOPE,
+    audience: AGGREGATES_API_AUDIENCE_ID,
+    response_type: "token",
+    client_id: AGGREGATES_APP_CLIENT_ID,
+    redirect_uri: currentUrl.toString(),
+		state: gRequestState,
+  };
+
+  let loginUrl = new URL(AUTH0_ORIGIN + "authorize");
+  for (let [key, value] of Object.entries(params)) {
+    loginUrl.searchParams.append(key, value);
+  }
+
+  return loginUrl.toString();
+}
+
+function constructLogoutUrl() {
+  let currentUrl = new URL(window.location.href);
+  // Discard the hash in case there's an access_token in it. The dashboard
+  // will restore state from Cookie.
+  currentUrl.hash = "";
+
+  let logoutUrl = new URL(AUTH0_ORIGIN + "v2/logout");
+  logoutUrl.searchParams.append("returnTo", currentUrl.toString());
+
+  return logoutUrl.toString();
+}
+
+function displayAuthButton(buttonText, buttonUrl) {
+  const lockIcon = document.createElement("i");
+  lockIcon.className = "fa fa-lock";
+
+  const button = document.createElement("a");
+  button.className = "btn btn-default";
+  button.id = "auth-button";
+  button.appendChild(lockIcon);
+  button.appendChild(document.createTextNode(buttonText));
+  button.href = buttonUrl;
+
+  const form = document.getElementById("auth-form");
+  form.appendChild(button);
+}
+
+window.addEventListener("DOMContentLoaded", () => {
+  if (!gAccessToken) {
+    displayAuthButton(" Login", constructLoginUrl());
+  } else {
+    displayAuthButton(" Log out", constructLogoutUrl());
+  }
+});
+
+/* Adapted from auth0.com with implicit licence: getParameterByName */
+function getParameterByName(hash, name) {
+  const match = RegExp("[#&]" + name + "=([^&]*)").exec(hash);
+  return match && decodeURIComponent(match[1].replace(/\+/g, " "));
+}
+
+function extractAuth0FromUrl(url) {
+  const hash = url.hash;
+  gAccessToken = getParameterByName(hash, "access_token");
+  gExpiresIn = getParameterByName(hash, "expires_in");
+  gResponseState = getParameterByName(hash, "state");
+  gRequestState = localStorage.getItem("gRequestState");
+  if (gAccessToken && gResponseState !== gRequestState) {
+    gAccessToken = null;
+    console.error("Response state doesn't match request state. Aborting auth.");
+  } else {
+    // Inform telemetry.js of our user's access token.
+    Telemetry.AuthorizationToken = gAccessToken;
+  }
+}
+
+// See if there's a token here for our use.
+extractAuth0FromUrl(new URL(window.location.href));
+
+// Register an auth failed listener with telemetry.js.
+Telemetry.AuthorizationFailed = () => {
+  window.location = constructLoginUrl();
+};
+
+})();

--- a/new-pipeline/src/dashboards.js
+++ b/new-pipeline/src/dashboards.js
@@ -1109,3 +1109,41 @@ function getUseCounterLink(metric, channel, description) {
   }).text(" View in use counter dashboard."));
   return useCounterLink;
 }
+
+function saveStateStringToUrl(stateString) {
+  // Save to the URL hash if it changed
+  var url = "";
+  var index = window.location.href.indexOf("#");
+  if (index > -1) {
+    url = decodeURI(window.location.href.substring(index + 1));
+  }
+  if (url[0] == "!") {
+    url = url.slice(1);
+  }
+  if (url !== stateString) {
+    window.location.replace(window.location.origin + window.location.pathname +
+      "#!" + encodeURI(stateString));
+    $(".permalink-control input")
+      .hide(); // Hide the permalink box again since the URL changed
+  }
+}
+
+function saveStateStringToCookie(stateString) {
+  // Save the state in a cookie that expires in 28 days
+  let expiry = new Date();
+  expiry.setTime(expiry.getTime() + (28 * 24 * 60 * 60 * 1000));
+  document.cookie = "stateFromUrl=" + stateString + "; expires=" + expiry.toGMTString();
+}
+
+function buildStateString(pageState) {
+  return Object.keys(pageState)
+    .sort()
+    .map(function (key) {
+      var value = pageState[key];
+      if ($.isArray(value)) {
+        value = value.join("!");
+      }
+      return encodeURIComponent(key) + "=" + encodeURIComponent(value);
+    })
+    .join("&");
+}

--- a/new-pipeline/src/dashboards.js
+++ b/new-pipeline/src/dashboards.js
@@ -426,7 +426,8 @@ function getHumanReadableOptions(filterName, options) {
   var channelVersionOrder = {
     "nightly": 0,
     "aurora": 1,
-    "beta": 2
+    "beta": 2,
+    "release": 3,
   };
   var productNames = {
     "Firefox": "Firefox Desktop",
@@ -654,7 +655,8 @@ function getHumanReadableOptions(filterName, options) {
           (version <= latestNightlyVersion - 1 ? goodOptions : badOptions)
           .push(option);
         } else if (parts[0] === "release") {
-          return;
+          (version <= latestNightlyVersion - 2 ? goodOptions : badOptions)
+          .push(option);
         } else {
           badOptions.push(option);
         }

--- a/new-pipeline/src/dist.js
+++ b/new-pipeline/src/dist.js
@@ -1703,37 +1703,9 @@ function saveStateToUrlAndCookie() {
     gInitialPageState.processType = selected;
   }
 
-  var stateString = Object.keys(gInitialPageState)
-    .sort()
-    .map(function (key) {
-      var value = gInitialPageState[key];
-      if ($.isArray(value)) {
-        value = value.join("!");
-      }
-      return encodeURIComponent(key) + "=" + encodeURIComponent(value);
-    })
-    .join("&");
-
-  // Save to the URL hash if it changed
-  var url = "";
-  var index = window.location.href.indexOf("#");
-  if (index > -1) {
-    url = decodeURI(window.location.href.substring(index + 1));
-  }
-  if (url[0] == "!") {
-    url = url.slice(1);
-  }
-  if (url !== stateString) {
-    window.location.replace(window.location.origin + window.location.pathname +
-      "#!" + encodeURI(stateString));
-    $(".permalink-control input")
-      .hide(); // Hide the permalink box again since the URL changed
-  }
-
-  // Save the state in a cookie that expires in 28 days
-  var expiry = new Date();
-  expiry.setTime(expiry.getTime() + (28 * 24 * 60 * 60 * 1000));
-  document.cookie = "stateFromUrl=" + stateString + "; expires=" + expiry.toGMTString();
+  var stateString = buildStateString(gInitialPageState);
+  saveStateStringToUrl(stateString);
+  saveStateStringToCookie(stateString);
 
   // Add link to switch to the evolution dashboard with the same settings
   var dashboardURL = window.location.origin + window.location.pathname.replace(

--- a/new-pipeline/src/dist.js
+++ b/new-pipeline/src/dist.js
@@ -36,6 +36,19 @@ $(function () {
   ]
     gInitialPageState = loadStateFromUrlAndCookie();
 
+    // If we don't have release versions and the page state is for release,
+    // trigger an authorization failure flow
+    let maxIsRelease = gInitialPageState.max_channel_version &&
+                       gInitialPageState.max_channel_version.startsWith("release/");
+    if (maxIsRelease &&
+        typeof Telemetry.AuthorizationFailed === "function" &&
+        !Telemetry.getVersions().filter(cv => cv.startsWith("release/")).length
+    ) {
+      // Persist state to cookie so it can survive the auth flow.
+      saveStateStringToCookie(buildStateString(gInitialPageState));
+      Telemetry.AuthorizationFailed();
+    }
+
     // Set up settings selectors
     multiselectSetOptions($("#channel-version"),
       getHumanReadableOptions("channelVersion", Telemetry.getVersions())

--- a/new-pipeline/src/evo.js
+++ b/new-pipeline/src/evo.js
@@ -1004,37 +1004,9 @@ function saveStateToUrlAndCookie() {
     gInitialPageState.processType = selected;
   }
 
-  var stateString = Object.keys(gInitialPageState)
-    .sort()
-    .map(function (key) {
-      var value = gInitialPageState[key];
-      if ($.isArray(value)) {
-        value = value.join("!");
-      }
-      return encodeURIComponent(key) + "=" + encodeURIComponent(value);
-    })
-    .join("&");
-
-  // Save to the URL hash if it changed
-  var url = "";
-  var index = window.location.href.indexOf("#");
-  if (index > -1) {
-    url = decodeURI(window.location.href.substring(index + 1));
-  }
-  if (url[0] == "!") {
-    url = url.slice(1);
-  }
-  if (url !== stateString) {
-    window.location.replace(window.location.origin + window.location.pathname +
-      "#!" + encodeURI(stateString));
-    $(".permalink-control input")
-      .hide(); // Hide the permalink box again since the URL changed
-  }
-
-  // Save the state in a cookie that expires in 28 days
-  var expiry = new Date();
-  expiry.setTime(expiry.getTime() + (28 * 24 * 60 * 60 * 1000));
-  document.cookie = "stateFromUrl=" + stateString + "; expires=" + expiry.toGMTString();
+  var stateString = buildStateString(gInitialPageState);
+  saveStateStringToUrl(stateString);
+  saveStateStringToCookie(stateString);
 
   // Add link to switch to the evolution dashboard with the same settings
   var dashboardURL = window.location.origin + window.location.pathname.replace(

--- a/v2/telemetry.js
+++ b/v2/telemetry.js
@@ -365,7 +365,7 @@
             .getTime();
         } else { // Result was invalid, remove the current request from the cache
           delete Telemetry.CACHE[url];
-          if (this.status === 401) { // Authorization failure. Notify listener.
+          if (this.status === 403) { // Authorization failure. Notify listener.
             if (typeof Telemetry.AuthorizationFailed === "function") {
               Telemetry.AuthorizationFailed();
             }

--- a/v2/telemetry.js
+++ b/v2/telemetry.js
@@ -9,7 +9,7 @@
   }
 
   var Telemetry = {
-    BASE_URL: 'https://aggregates.telemetry.mozilla.org/',
+    BASE_URL: 'https://mozaggregator.stage.mozaws.net/',
     CHANNEL_VERSION_DATES: null,
     CHANNEL_VERSION_BUILDIDS: null,
     CACHE: {},
@@ -386,8 +386,7 @@
     };
     xhr.open("get", url, true);
     if (Telemetry.AuthorizationToken) {
-      // Cannot currently set this header as aggregates.tmo's CORS settings forbids this header
-      // xhr.setRequestHeader("Authorization", "Bearer " + Telemetry.AuthorizationToken);
+      xhr.setRequestHeader("Authorization", "Bearer " + Telemetry.AuthorizationToken);
     }
     xhr.send();
   }

--- a/v2/telemetry.js
+++ b/v2/telemetry.js
@@ -600,6 +600,9 @@
     assert((fromVersion === undefined && toVersion === undefined) || (
         typeof fromVersion === "string" && typeof toVersion === "string"),
       "`fromVersion` and `toVersion` must be strings");
+    if (fromVersion && fromVersion.split("/")[0] !== toVersion.split("/")[0]) {
+      return [];
+    }
     var versions = [];
     for (var channel in Telemetry.CHANNEL_VERSION_DATES) {
       for (var version in Telemetry.CHANNEL_VERSION_DATES[channel]) {

--- a/v2/telemetry.js
+++ b/v2/telemetry.js
@@ -365,6 +365,11 @@
             .getTime();
         } else { // Result was invalid, remove the current request from the cache
           delete Telemetry.CACHE[url];
+          if (this.status === 401) { // Authorization failure. Notify listener.
+            if (typeof Telemetry.AuthorizationFailed === "function") {
+              Telemetry.AuthorizationFailed();
+            }
+          }
         }
         callback(null, this.status);
       } else { // Request was successful
@@ -380,6 +385,10 @@
       callback(null, this.status);
     };
     xhr.open("get", url, true);
+    if (Telemetry.AuthorizationToken) {
+      // Cannot currently set this header as aggregates.tmo's CORS settings forbids this header
+      // xhr.setRequestHeader("Authorization", "Bearer " + Telemetry.AuthorizationToken);
+    }
     xhr.send();
   }
 


### PR DESCRIPTION
By all means give it a try. Head to https://chutten.github.io/telemetry-dashboard/ and get into the Measurement Dashboard. There's a little login button at the top-right. It should redirect you to my auth0 for auth 

user: user2@domain.com
pass: U$erdomain

If you successfully authenticate the login button should disappear and your access token will be at `window.Telemetry.AuthorizationToken`

Limitations: 
* Each navigation needs new auth
  * This includes refreshes and new tabs in addition to navigating between evo and dist
  * Auth0 is smart enough to auth you almost silently, so subsequent logins are just a matter of clicking the login button. No credentials. This may be low-friction enough for MVP, or may not.
* No UI to let users know if they've auth'd or not.
  * The entire design is in need of review, so this isn't much surprise
* Doesn't transmit auth to aggregates.tmo
  * aggregates.tmo actually has some CORS on it saying we can't send any but the most standard of headers. `Authorization` isn't a "most standard" so I had to comment it out.
* No handling for token expiry
  * Tokens are configured to be valid for 2 hours, but I've not implemented any way of renewing it beforehand or handling a case where auth goes wrong.
  * User sessions are short enough and Auth0 authentication is seamless enough that this might be acceptable for MVP.
