### PR TITLE
Remove the Firefox Hardware Report

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,10 +36,6 @@
                         Firefox Public Data Report
                         <div class="dashboard-description">See the activity, behavior, and hardware configuration of Firefox users.</div>
                     </a>
-                    <a class="list-group-item" href="https://metrics.mozilla.com/firefox-hardware-report/">
-                        Firefox Hardware Report
-                        <div class="dashboard-description">See what hardware Firefox users have.</div>
-                    </a>
                     <a class="list-group-item" href="https://sql.telemetry.mozilla.org/">
                         SQL Portal <span class="fa fa-lock"></span>
                         <div class="dashboard-description">View dashboards &amp; run SQL queries.</div>


### PR DESCRIPTION
The Firefox Hardware Report now only redirects to to the Hardware page
of the Firefox Public Data Report.