### PR TITLE
 Fix probe-dictionary event details

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,6 +32,10 @@
                         Measurement Dashboard
                         <div class="dashboard-description">View the measure distributions and evolutions over time.</div>
                     </a>
+                    <a class="list-group-item" href="https://data.firefox.com/">
+                        Firefox Public Data Report
+                        <div class="dashboard-description">See the activity, behavior, and hardware configuration of Firefox users.</div>
+                    </a>
                     <a class="list-group-item" href="https://metrics.mozilla.com/firefox-hardware-report/">
                         Firefox Hardware Report
                         <div class="dashboard-description">See what hardware Firefox users have.</div>

--- a/probe-dictionary/explore.js
+++ b/probe-dictionary/explore.js
@@ -943,9 +943,9 @@ function showDetailViewForId(probeId, channel=$("#select_channel").val()) {
     ['high', 'detail-histogram-high', ['histogram']],
     ['n_buckets', 'detail-histogram-bucket-count', ['histogram']],
 
-    ['extra_keys', 'detail-event-methods', ['event']],
-    ['methods', 'detail-event-objects', ['event']],
-    ['objects', 'detail-event-extra-keys', ['event']],
+    ['methods', 'detail-event-methods', ['event']],
+    ['objects', 'detail-event-objects', ['event']],
+    ['extra_keys', 'detail-event-extra-keys', ['event']],
   ];
 
   var pretty = (prop) => {


### PR DESCRIPTION
The event detail view was putting the objects, methods & extra keys into the wrong elements.