### PR TITLE
Fix for issue #575: Dev edition charts show up as aurora in chart labels

### DIFF
--- a/new-pipeline/src/evo.js
+++ b/new-pipeline/src/evo.js
@@ -217,7 +217,7 @@ $(function () {
               var latestChannelVersion = Infinity;
               if (channel === "nightly") {
                 latestChannelVersion = latestNightlyVersion;
-              } else if (channel === "aurora") {
+              } else if (channel === "dev edition") {
                 latestChannelVersion = latestNightlyVersion - 1;
               } else if (channel === "beta") {
                 latestChannelVersion = latestNightlyVersion - 2;
@@ -907,6 +907,9 @@ var Line = (function () {
 
     this.measure = measure;
     this.channelVersion = channelVersion;
+    if (channelVersion === "aurora") {
+      this.channelVersion = "dev edition";
+    }
     this.aggregate = aggregate;
     this.values = values || [];
 

--- a/probe-dictionary/explore.js
+++ b/probe-dictionary/explore.js
@@ -946,6 +946,7 @@ function showDetailViewForId(probeId, channel=$("#select_channel").val()) {
     ['methods', 'detail-event-methods', ['event']],
     ['objects', 'detail-event-objects', ['event']],
     ['extra_keys', 'detail-event-extra-keys', ['event']],
+    ['see_more', 'see-more', ['environment']],
   ];
 
   var pretty = (prop) => {
@@ -968,6 +969,15 @@ function showDetailViewForId(probeId, channel=$("#select_channel").val()) {
       $('#' + id).text("");
       document.getElementById(id).parentElement.classList.add("hidden");
     }
+  }
+
+  var seeMoreRow = document.getElementById("see-more-row");
+  if (probeId.includes("environment/addons.activeAddons")) {
+    $("#see-more").empty();
+    $("#see-more").append('<a href="https://telemetry.mozilla.org/probe-dictionary/?search=addons.activeAddons">All properties for addons.activeAddons</a>');
+    seeMoreRow.classList.remove("hidden");
+  } else {
+    seeMoreRow.classList.add("hidden"); 
   }
 
   document.getElementById("probe-detail-view").classList.remove("hidden");

--- a/probe-dictionary/index.html
+++ b/probe-dictionary/index.html
@@ -187,6 +187,9 @@
         <tr title="Some probes have a 'C++ guard' set, which generates a preprocessor statement in Firefox code. This is used to limit probes to record only on some platforms or products.">
           <td class="fit pr-2">Preprocessor guard:</td><td id="detail-cpp-guard" class="grow"></td>
         </tr>
+	<tr id="see-more-row">
+		<td class="fit pr-2">See More:</td><td id="see-more" class="grow"></td>
+	</tr>
       </table>
     </div>
   </div>


### PR DESCRIPTION
Changing channelVersion to "Dev Edition" from "Aurora" in Line constructor.