### PR TITLE
Remove "Analysis Portal" link

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,10 +47,6 @@
                       Databricks <span class="fa fa-lock"></span>
                       <div class="dashboard-description">Analyze telemetry data with Spark.</div>
                     </a>
-                    <a class="list-group-item" href="https://analysis.telemetry.mozilla.org/">
-                        Analysis Portal <span class="fa fa-lock"></span>
-                        <div class="dashboard-description">Analyze telemetry data with Spark.</div>
-                    </a>
                     <a class="list-group-item" href="https://experimenter.services.mozilla.com/">
                         Experimenter <span class="fa fa-lock"></span>
                         <div class="dashboard-description">Create, monitor &amp; review Shield studies.</div>


### PR DESCRIPTION
ATMO is no more, so this link is dead.