### PR TITLE
Bug 1595313 - Remove warning for partial outage of prerelease data 

### DIFF
--- a/new-pipeline/dist.html
+++ b/new-pipeline/dist.html
@@ -32,11 +32,6 @@
             </form>
             <h1>Measurement Dashboard</h1>
             <div class="error-msg">
-                <span style="font-weight: bold">Partial outage of pre-release data from 2019-11-07 to present. </span>
-                Please watch
-                <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1595313">Bug 1595313</a> for updates.
-            </div>
-            <div class="error-msg">
                 <span style="font-weight: bold">Partial outage of release data from 2018-12-17 to present. </span>
                 We are experiencing issues in the underlying dataset that results in the Measurement Dashboards
                 showing no data after December 17 for release data only. We are sorry for

--- a/new-pipeline/evo.html
+++ b/new-pipeline/evo.html
@@ -30,11 +30,6 @@
             </form>
             <h1>Evolution Dashboard</h1>
             <div class="error-msg">
-                <span style="font-weight: bold">Partial outage of pre-release data from 2019-11-07 to present. </span>
-                Please watch
-                <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1595313">Bug 1595313</a> for updates.
-            </div>
-            <div class="error-msg">
                 <span style="font-weight: bold">Partial outage of release data from 2018-12-17 to present. </span>
                 We are experiencing issues in the underlying dataset that results in the Measurement Dashboards
                 showing no data after December 17 for release data only. We are sorry for


### PR DESCRIPTION
[bug link](https://bugzilla.mozilla.org/show_bug.cgi?id=1595313)