### PR TITLE
 Bug 1605442 - mozaggregator missing prerelease data since 2019-12-18

### DIFF
--- a/new-pipeline/dist.html
+++ b/new-pipeline/dist.html
@@ -32,6 +32,10 @@
             </form>
             <h1>Measurement Dashboard</h1>
             <div class="error-msg">
+                <span style="font-weight: bold">Partial outage of pre-release data from 2019-12-18 to present. </span>
+                 Refer to <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1605442">Bug 1605442</a> for updates.
+            </div>
+            <div class="error-msg">
                 <span style="font-weight: bold">Partial outage of release data from 2018-12-17 to present. </span>
                 We are experiencing issues in the underlying dataset that results in the Measurement Dashboards
                 showing no data after December 17 for release data only. We are sorry for

--- a/new-pipeline/evo.html
+++ b/new-pipeline/evo.html
@@ -30,6 +30,10 @@
             </form>
             <h1>Evolution Dashboard</h1>
             <div class="error-msg">
+                <span style="font-weight: bold">Partial outage of pre-release data from 2019-12-18 to present. </span>
+                 Refer to <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1605442">Bug 1605442</a> for updates.
+            </div>
+            <div class="error-msg">
                 <span style="font-weight: bold">Partial outage of release data from 2018-12-17 to present. </span>
                 We are experiencing issues in the underlying dataset that results in the Measurement Dashboards
                 showing no data after December 17 for release data only. We are sorry for


### PR DESCRIPTION
[bug link](https://bugzilla.mozilla.org/show_bug.cgi?id=1605442)