### PR TITLE
Bug 1605442 - mozaggregator missing prerelease data since 2019-01-09

### DIFF
--- a/new-pipeline/dist.html
+++ b/new-pipeline/dist.html
@@ -32,7 +32,7 @@
             </form>
             <h1>Measurement Dashboard</h1>
             <div class="error-msg">
-                <span style="font-weight: bold">Partial outage of pre-release data from 2019-12-18 to present. </span>
+                <span style="font-weight: bold">Partial outage of pre-release data from 2019-01-09 to present. </span>
                  Refer to <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1605442">Bug 1605442</a> for updates.
             </div>
             <div class="error-msg">

--- a/new-pipeline/evo.html
+++ b/new-pipeline/evo.html
@@ -30,7 +30,7 @@
             </form>
             <h1>Evolution Dashboard</h1>
             <div class="error-msg">
-                <span style="font-weight: bold">Partial outage of pre-release data from 2019-12-18 to present. </span>
+                <span style="font-weight: bold">Partial outage of pre-release data from 2019-01-09 to present. </span>
                  Refer to <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1605442">Bug 1605442</a> for updates.
             </div>
             <div class="error-msg">


### PR DESCRIPTION
Updating status as the service plays catch-up.