### PR TITLE
Bug 1621979 - update the update orphaning dashboard.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ validation/
 html/data
 out.txt
 Histograms.json
+.DS_Store

--- a/update-orphaning/index.html
+++ b/update-orphaning/index.html
@@ -97,8 +97,11 @@ criteria are applied is the same order as they are listed above.</div>
 <div id="state-failure-code-startup-link" class="bar-chart-link"></div>
 </div><br/>
 <hr>
-This dashboard is maintained by <a href="mailto:rstrong@mozilla.com">:rstrong</a>.<br/>
-The Spark Notebook for this dashboard is scheduled to run on Monday and Tuesday every week since the longitudinal datasource isn't consistently available on Monday. The Spark Notebook can be found <a href="https://github.com/mozilla/mozilla-reports/tree/master/projects/app_update_out_of_date.kp/orig_src/app_update_out_of_date.ipynb">here</a>.
+This dashboard is maintained by the <a href="https://chat.mozilla.org/#/room/#install-update:mozilla.org">install/update team</a>.<br/>
+This content is updated every Monday, starting at 2:00 UTC. It takes about 30 mins to complete.
+
+The dataset is configured <a href="https://github.com/mozilla/telemetry-airflow/blob/master/jobs/update_orphaning_dashboard_etl.py">here</a>, and the scheduling logic is <a href="https://github.com/mozilla/telemetry-airflow/blob/master/dags/update_orphaning_dashboard_etl.py#L28-L29">here</a>.
+
 <div><a href="https://www.mozilla.org/en-US/privacy/websites/">Mozilla's Website Privacy Notice</a></div>
 <script src="../analytics/analytics.js"></script>
 </div>

--- a/update-orphaning/index.js
+++ b/update-orphaning/index.js
@@ -1024,6 +1024,12 @@ function populateDashboard(event) {
                              "desc": "OS X and Linux update watershed to add LZMA update compression support (see " +
                                      "<a href='https://bugzilla.mozilla.org/show_bug.cgi?id=641212'>Bug 641212</a>)."};
             break;
+          case "72.0.2":
+            labelName = labelName + " (Password migration watershed)";
+            detailRows[4] = {"labelName": labelName, "subset": ofConcernByVersion[v],
+                              "desc": "Watershed for all platforms to support password migration (see " +
+                                      "<a href='https://bugzilla.mozilla.org/show_bug.cgi?id=1607798'>Bug 1607798</a>)."};
+            break;
           default:
             // Store this version's information so it can be evaluated later to
             // determine whether it should be combined with other versions for
@@ -1090,7 +1096,8 @@ function populateDashboard(event) {
                    "Out of date, of concern client distribution across Firefox versions",
                    versionSlices, "label-asc");
 
-      for (var i = 0; i < 4; i++) {
+      var detailCount = detailRows.length;
+      for (var i = 0; i < detailCount; i++) {
         if (detailRows[i]) {
           updateDetailsRow("version-dist-details", i, detailRows[i].subset, ofConcernTrue, detailRows[i].labelName,
                            detailRows[i].desc);


### PR DESCRIPTION
Making a few small updates to [this dashboard](https://telemetry.mozilla.org/update-orphaning/):

* Adjusting text/links around maintainers.
* Adding details for 72.0.2 watershed 

I'd originally come in here to update the `Firefox version is 72 or higher...` text, not realizing that actually the text is [dynamically generated](https://github.com/mozilla/telemetry-dashboard/blob/gh-pages/update-orphaning/index.js#L819) and the response we're getting back is correct and up to date. We're considering FF versions that are 2 behind release to still be "up to date". Since the most recent FF version for the current dataset was 74 (should be updating [about now to 75](https://github.com/mozilla/telemetry-airflow/blob/master/dags/update_orphaning_dashboard_etl.py#L28-L29)) then the fact that we're still seeing 72 is expected.

