### PR TITLE
Add GUD to TMO

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,6 +43,10 @@
                     <a class="list-group-item" href="https://missioncontrol.telemetry.mozilla.org/">
                       Mission Control <div class="dashboard-description">View key Firefox quality measures in near-realtime.</div>
                     </a>
+                    <a class="list-group-item" href="https://growth-stage.bespoke.nonprod.dataops.mozgcp.net">
+                      Growth &amp; Usage Dashboard (GUD) <span class="fa fa-lock"></span>
+                      <div class="dashboard-description">Usage and retention metrics for Mozilla products.</div>
+                    </a>
                     <a class="list-group-item" href="https://sso.mozilla.com/databricks">
                       Databricks <span class="fa fa-lock"></span>
                       <div class="dashboard-description">Analyze telemetry data with Spark.</div>


### PR DESCRIPTION
GUD still does not have a production URL, but it's used as a production reference source, so I think it's time we added it here.