### PR TITLE
Remove arewesmoothyet.com reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,9 +117,6 @@
                     <a class="list-group-item" href="update-orphaning/">
                         Update Orphaning <div class="dashboard-description">View percentage breakdowns of users who are up-to-date vs. out-of-date.</div>
                     </a>
-                    <a class="list-group-item" href="https://arewesmoothyet.com/">
-                        Background Hang Reporting <div class="dashboard-description">View browser hang information collected from Nightly users</div>
-                    </a>
                     <a class="list-group-item" href="histogram-simulator/">
                         Histogram Simulator <div class="dashboard-description">Simulate histogram bucket widths</div>
                     </a>


### PR DESCRIPTION
It is no longer maintained and the domain registration lapsed.