### PR TITLE
Update dictionary links

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,11 +65,11 @@
                     <a class="list-group-item" href="https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/">
                         Firefox Telemetry Docs <div class="dashboard-description">Learn how to record data &amp; what data gets sent.</div>
                     </a>
-                    <a class="list-group-item" href="https://probes.telemetry.mozilla.org/">
-                        Probe Dictionary <div class="dashboard-description">Find what probes are submitted from Firefox.</div>
-                    </a>
-                    <a class="list-group-item" href="https://dictionary.protosaur.dev/">
+                    <a class="list-group-item" href="https://dictionary.telemetry.mozilla.org/">
                         Glean Dictionary <div class="dashboard-description">Next-generation data dictionary for Firefox for Android and other applications built using the Glean SDK.</div>
+                    </a>
+                    <a class="list-group-item" href="https://probes.telemetry.mozilla.org/">
+                        Probe Dictionary <div class="dashboard-description">Find what probes are submitted from Firefox (using legacy non-Glean telemetry).</div>
                     </a>
                     <a class="list-group-item" href="https://mana.mozilla.org/wiki/display/FIREFOX/Pref-Flip+and+Add-On+Experiments#Pref-FlipandAdd-OnExperiments-GettingStarted">
                         Shield Study Docs <span class="fa fa-lock"></span>


### PR DESCRIPTION
* Use production URL for Glean Dictionary
* Make it a little more clear that the probe dictionary is for legacy telemetry