### PR TITLE
Remove data fault notice, add GLAM button

### DIFF
--- a/new-pipeline/dist.html
+++ b/new-pipeline/dist.html
@@ -23,7 +23,7 @@
             <form class="navbar-form inline pull-right btn-group">
                 <a href="#" class="btn btn-default permalink-button" title="Get Shortlink"><i class="fa fa-link"></i> Get Shortlink</a>
                 <input type="text" class="permalink-text input btn btn-default">
-                <a href="https://github.com/mozilla/telemetry-dashboard/issues" class="btn btn-success" title="Report a bug in Telemetry dashboards" target="_blank"><i class="fa fa-bug"></i> Report bug</a>
+                <a href="https://glam.telemetry.mozilla.org/" class="btn btn-success" title="GLAM: Glean Aggregate Metrics Dashboard" target="_blank"><i class="fa fa-lock"></i> Use GLAM</a>
                 <a href="/" class="btn btn-default btn-primary" title="Landing page for Telemetry dashboards"><i class="fa fa-home"></i> Telemetry Portal</a>
                 <a href="./tutorial.html#HistogramDashboard" class="btn btn-default" id="tutorial" title="Usage tutorial for Telemetry dashboards"><i class="fa fa-question-circle"></i> Usage Tutorial</a>
             </form>

--- a/new-pipeline/dist.html
+++ b/new-pipeline/dist.html
@@ -28,13 +28,6 @@
                 <a href="./tutorial.html#HistogramDashboard" class="btn btn-default" id="tutorial" title="Usage tutorial for Telemetry dashboards"><i class="fa fa-question-circle"></i> Usage Tutorial</a>
             </form>
             <h1>Measurement Dashboard</h1>
-            <div class="error-msg">
-                <span style="font-weight: bold">Partial outage of data from 2021-06-17 to present.</span>
-                The database has been having a bad time since June 17 causing data after June 15 to not be shown.
-                We are sorry for the inconvenience. Data in <a href="https://glam.telemetry.mozilla.org">GLAM</a>
-                is unaffected. Please follow
-                <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1716802">Bug 1716802</a> for updates.
-            </div>
         </header>
         <ul class="nav nav-tabs">
             <li class="active" ><a href="#"><i class="fa fa-bar-chart"></i><strong>  Distribution</strong></a></li>

--- a/new-pipeline/evo.html
+++ b/new-pipeline/evo.html
@@ -21,7 +21,7 @@
             <form class="navbar-form inline pull-right btn-group">
                 <a href="#" class="btn btn-default permalink-button" title="Get Shortlink"><i class="fa fa-link"></i> Get Shortlink</a>
                 <input type="text" class="permalink-text input btn btn-default">
-                <a href="https://github.com/mozilla/telemetry-dashboard/issues" class="btn btn-success" title="Report a bug in Telemetry dashboards" target="_blank"><i class="fa fa-bug"></i> Report bug</a>
+                <a href="https://glam.telemetry.mozilla.org/" class="btn btn-success" title="GLAM: Glean Aggregate Metrics Dashboard" target="_blank"><i class="fa fa-lock"></i> Use GLAM</a>
                 <a href="/" class="btn btn-default btn-primary" title="Landing page for Telemetry dashboards"><i class="fa fa-home"></i> Telemetry Portal</a>
                 <a href="./tutorial.html#EvolutionDashboard" class="btn btn-default" id="tutorial" title="Usage tutorial for Telemetry dashboards"><i class="fa fa-question-circle"></i> Usage Tutorial</a>
             </form>

--- a/new-pipeline/evo.html
+++ b/new-pipeline/evo.html
@@ -26,13 +26,6 @@
                 <a href="./tutorial.html#EvolutionDashboard" class="btn btn-default" id="tutorial" title="Usage tutorial for Telemetry dashboards"><i class="fa fa-question-circle"></i> Usage Tutorial</a>
             </form>
             <h1>Evolution Dashboard</h1>
-            <div class="error-msg">
-                <span style="font-weight: bold">Partial outage of data from 2021-06-17 to present.</span>
-                The database has been having a bad time since June 17 causing data after June 15 to not be shown.
-                We are sorry for the inconvenience. Data in <a href="https://glam.telemetry.mozilla.org">GLAM</a>
-                is unaffected. Please follow
-                <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1716802">Bug 1716802</a> for updates.
-            </div>
         </header>
         <ul class="nav nav-tabs">
             <li><a href="./dist.html"><i class="fa fa-bar-chart"></i><strong>  Distribution</strong></a></li>


### PR DESCRIPTION
The data fault's been resolved.

GLAM is preferred if you have a moz LDAP, and the Dashboards are in maintenance mode (more-or-less), so replace the 'file a bug' button with 'use glam'.

Live preview: https://chutten.github.io/telemetry-dashboard/new-pipeline/dist.html