### PR TITLE
Revert "bug 1752803 - Apply data fault error for mozaggregates issue"

### DIFF
--- a/new-pipeline/dist.html
+++ b/new-pipeline/dist.html
@@ -28,13 +28,6 @@
                 <a href="./tutorial.html#HistogramDashboard" class="btn btn-default" id="tutorial" title="Usage tutorial for Telemetry dashboards"><i class="fa fa-question-circle"></i> Usage Tutorial</a>
             </form>
             <h1>Measurement Dashboard</h1>
-            <div class="error-msg">
-                <span style="font-weight: bold">No new data from 2022-01-28.</span>
-                The job responsible for the data powering these dashboards has been having problems lately.
-                Data since Jan 28 may not be present until this is resolved.
-                We are sorry for the inconvenience. Please follow
-                <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1752803">Bug 1752803</a> for updates.
-            </div>
         </header>
         <ul class="nav nav-tabs">
             <li class="active" ><a href="#"><i class="fa fa-bar-chart"></i><strong>  Distribution</strong></a></li>

--- a/new-pipeline/evo.html
+++ b/new-pipeline/evo.html
@@ -26,13 +26,6 @@
                 <a href="./tutorial.html#EvolutionDashboard" class="btn btn-default" id="tutorial" title="Usage tutorial for Telemetry dashboards"><i class="fa fa-question-circle"></i> Usage Tutorial</a>
             </form>
             <h1>Evolution Dashboard</h1>
-            <div class="error-msg">
-                <span style="font-weight: bold">No new data from 2022-01-28.</span>
-                The job responsible for the data powering these dashboards has been having problems lately.
-                Data since Jan 28 may not be present until this is resolved.
-                We are sorry for the inconvenience. Please follow
-                <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1752803">Bug 1752803</a> for updates.
-            </div>
         </header>
         <ul class="nav nav-tabs">
             <li><a href="./dist.html"><i class="fa fa-bar-chart"></i><strong>  Distribution</strong></a></li>


### PR DESCRIPTION
This reverts commit 6a317f28f60c0bca69f7269a90659d2cdb9e29ab. `prerelease_telemetry_aggregates` DAG has been backfilled successfully and the TMO dashboard is now updated. See [1751206](https://bugzilla.mozilla.org/show_bug.cgi?id=1751206).
