### PR TITLE
Use the AMO API v4

### DIFF
--- a/addon-recommender/js/main.js
+++ b/addon-recommender/js/main.js
@@ -12,7 +12,7 @@ const addonMappingURI =
 
 // The AMO API endpoint used to request the top addons.
 const topAddonsURI =
-  'https://addons.mozilla.org/api/v3/addons/search/?q=&app=firefox&type=extension&sort=users';
+  'https://addons.mozilla.org/api/v4/addons/search/?q=&app=firefox&type=extension&sort=users';
 
 function setupAutocomplete() {
   var suggestions = []


### PR DESCRIPTION
v3 is deprecated and soon to be removed.

Fixes #661

---

The addon recommender is not linked anywhere from TMO directly, so maybe we should just remove it fully? Just changing it was the safer way though.