### PR TITLE
Update the CDN description in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repository also contains the **source code for Telemetry.js**. The specific
 Deploying Telemetry Dashboard
 -----------------------------
 
-The [telemetry.mozilla.org](https://telemetry.mozilla.org) site is hosted in [Github Pages](https://pages.github.com/), so it may also be accessed via [mozilla.github.io/telemetry-dashboard](https://mozilla.github.io/telemetry-dashboard/). In front of Github Pages, there is also the CloudFront CDN (managed by :whd).
+The [telemetry.mozilla.org](https://telemetry.mozilla.org) site is hosted in [Github Pages](https://pages.github.com/), so it may also be accessed via [mozilla.github.io/telemetry-dashboard](https://mozilla.github.io/telemetry-dashboard/). In front of Github Pages, there is also a GCP CDN (managed by DSRE).
 
 Updates to the `gh-pages` branch (also the default branch) will be reflected on [telemetry.mozilla.org](https://telemetry.mozilla.org) after a few moments.
 


### PR DESCRIPTION
This file hasn't been updated in... over 4 years and this is certainly not the only thing out of date, but it is something I know that is specifically out of date as of this week.

As a side note, in the time since the original CDN was configured, github pages now supports handling custom domains via letsencrypt directly, but due to some quirks around cert provisioning in https://mozilla-hub.atlassian.net/browse/DSRE-512 it ended up being useful to maintain a CDN that is accessible via an A record in front of github pages for this domain anyway.