### PR TITLE
Add Experimenter Docs to the Data Portal

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,6 +137,14 @@
                     </div>
                 </a>
 
+                <a class="tool col" href="https://experimenter.info/">
+                    <img src="assets/nimbus.svg" />
+                    <div>
+                        <h3>Experimenter Docs</h3>
+                        <p>Your central resource for A/B experiments and feature rollouts in Firefox Mobile and Desktop.</p>
+                    </div>
+                </a>
+
                 <a class="tool col" href="https://mozilla.github.io/glean/book/index.html">
                     <img src="assets/glean.png" />
                     <div>


### PR DESCRIPTION
Add a link to Experimenter Docs in the Data Portal. I have trouble finding/remembering the link to Experimenter Docs sometimes, and the Data Portal seems like a great place for it to be. 